### PR TITLE
Add two-stage face detection pipeline with YuNet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ DB_NAME=face_attendance
 DB_USER=postgres
 DB_PASS=password
 DB_PORT=5432
+# Flask dashboard port
+#   Set to 5050 for macOS
+#   macOS uses port 5000 for AirPlay Receiver which is the default Flask port for Windows
+FLASK_PORT=
 # Distance threshold (lower is stricter)
 RECOGNITION_THRESHOLD=0.4
 # Minimum consecutive frames to confirm identity
@@ -13,3 +17,11 @@ CHECK_IN_COOLDOWN_MINUTES=1 # Reduced from 30 to 1 for testing purposes
 UNKNOWN_FACES_DIR=data/unknown/
 # Camera source: 0 for webcam, or "rtsp://..."
 CAMERA_SOURCE=0
+# Two-stage detection (optional, defaults are good for 4K RTSP)
+DETECTION_WIDTH=640
+DETECTION_HEIGHT=360
+DISPLAY_WIDTH=960
+DISPLAY_HEIGHT=540
+YUNET_SCORE_THRESHOLD=0.5
+YUNET_NMS_THRESHOLD=0.3
+FACE_CROP_PADDING=1.5

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 test_results/
 __pycache__/
 docs/
+models/*.onnx

--- a/config.py
+++ b/config.py
@@ -32,7 +32,21 @@ else:
 FLASK_PORT = int(os.getenv("FLASK_PORT", "5000"))
 
 # DeepFace Model Configuration
-MODEL_NAME = "Facenet512" # Matches the 512-dimension vector in our DB schema
+# Facenet512 matches the 512-dimension vector in our DB schema
+MODEL_NAME = "Facenet512"
 DETECTOR_BACKEND = "opencv"
-ENFORCE_DETECTION = False # Don't raise an error if a face isn't clearly found in every frame
+# Don't raise an error if a face isn't clearly found in every frame
+ENFORCE_DETECTION = False
 ALIGN = True
+
+# Two-stage detection configuration
+DETECTION_WIDTH = int(os.getenv("DETECTION_WIDTH", "640"))
+DETECTION_HEIGHT = int(os.getenv("DETECTION_HEIGHT", "360"))
+DISPLAY_WIDTH = int(os.getenv("DISPLAY_WIDTH", "960"))
+DISPLAY_HEIGHT = int(os.getenv("DISPLAY_HEIGHT", "540"))
+YUNET_SCORE_THRESHOLD = float(os.getenv("YUNET_SCORE_THRESHOLD", "0.5"))
+YUNET_NMS_THRESHOLD = float(os.getenv("YUNET_NMS_THRESHOLD", "0.3"))
+YUNET_MODEL_PATH = os.path.join(os.path.dirname(__file__), "models", "face_detection_yunet_2023mar.onnx")
+
+# Face crop padding multiplier (1.5 = 50% padding around detected face)
+FACE_CROP_PADDING = float(os.getenv("FACE_CROP_PADDING", "1.5"))

--- a/monitor.py
+++ b/monitor.py
@@ -1,22 +1,25 @@
-import cv2
-import psycopg2
-import signal
-import sys
 import os
-import shutil
+import signal
+from datetime import datetime
+
+import cv2
+import numpy as np
+import psycopg2
 from deepface import DeepFace
+
 import config
 from logger import log_check_in, log_unknown_detection
-from datetime import datetime
-import numpy as np
 
-# Global flag for exit
+FACE_CONFIDENCE_THRESHOLD = 0.6
+
 running = True
+
 
 def signal_handler(sig, frame):
     global running
     print("\nStopping monitoring...")
     running = False
+
 
 def get_connection():
     try:
@@ -26,17 +29,21 @@ def get_connection():
             user=config.DB_USER,
             password=config.DB_PASS,
             port=config.DB_PORT,
-            connect_timeout=5
+            connect_timeout=5,
         )
-    except:
+    except Exception:
         return None
 
+
 def normalize_frame(frame):
+    """Apply histogram equalization to the luminance channel."""
     yuv_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2YUV)
     yuv_frame[:, :, 0] = cv2.equalizeHist(yuv_frame[:, :, 0])
     return cv2.cvtColor(yuv_frame, cv2.COLOR_YUV2BGR)
 
+
 def query_database(embedding):
+    """Find the closest member by cosine distance. Returns (member_id, name, distance)."""
     conn = get_connection()
     if not conn:
         return None, "DB Error", None
@@ -45,7 +52,7 @@ def query_database(embedding):
         cur.execute(
             "SELECT id, name, face_embedding <=> %s::vector AS distance "
             "FROM members ORDER BY distance ASC LIMIT 1",
-            (list(embedding),)
+            (list(embedding),),
         )
         result = cur.fetchone()
         if result and result[2] < config.RECOGNITION_THRESHOLD:
@@ -57,15 +64,71 @@ def query_database(embedding):
     finally:
         conn.close()
 
+
+def extract_embedding(image):
+    """Run DeepFace extract + represent on an image. Returns (embedding, face_data) or None."""
+    faces = DeepFace.extract_faces(
+        img_path=image,
+        detector_backend=config.DETECTOR_BACKEND,
+        align=config.ALIGN,
+        enforce_detection=False,
+    )
+
+    for face_data in faces:
+        if face_data["confidence"] < FACE_CONFIDENCE_THRESHOLD:
+            continue
+
+        results = DeepFace.represent(
+            img_path=face_data["face"],
+            model_name=config.MODEL_NAME,
+            detector_backend="skip",
+            align=False,
+            enforce_detection=False,
+        )
+
+        if results:
+            return results[0]["embedding"], face_data
+
+    return None
+
+
+def handle_recognition(embedding, confirmation_buffer, image_to_save):
+    """Query database and update confirmation buffer. Returns the matched name."""
+    member_id, name, distance = query_database(embedding)
+
+    if member_id:
+        if confirmation_buffer["id"] == member_id:
+            confirmation_buffer["count"] += 1
+        else:
+            confirmation_buffer["id"] = member_id
+            confirmation_buffer["count"] = 1
+
+        if confirmation_buffer["count"] >= config.CONFIRMATION_FRAMES:
+            print(f"Confirmed match: {name} (Dist: {distance:.4f})")
+            log_check_in(member_id)
+            confirmation_buffer["count"] = 0
+
+    elif distance is not None and distance >= config.RECOGNITION_THRESHOLD:
+        print(f"Unknown face detected (Distance: {distance:.4f})")
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        image_path = os.path.join(config.UNKNOWN_FACES_DIR, f"unknown_{timestamp}.jpg")
+        cv2.imwrite(image_path, image_to_save)
+        log_unknown_detection(embedding, image_path)
+        confirmation_buffer["id"] = None
+        confirmation_buffer["count"] = 0
+
+    return name
+
+
 def cleanup_unknown():
     """Prompt user to empty the unknown faces directory."""
-    count = len([f for f in os.listdir(config.UNKNOWN_FACES_DIR) if f.endswith('.jpg')])
+    count = len([f for f in os.listdir(config.UNKNOWN_FACES_DIR) if f.endswith(".jpg")])
     if count == 0:
         return
-    
+
     print(f"\nThere are {count} unknown face captures in {config.UNKNOWN_FACES_DIR}.")
     choice = input("Would you like to clear these images? (y/n): ").strip().lower()
-    if choice == 'y':
+    if choice == "y":
         for filename in os.listdir(config.UNKNOWN_FACES_DIR):
             file_path = os.path.join(config.UNKNOWN_FACES_DIR, filename)
             try:
@@ -75,9 +138,132 @@ def cleanup_unknown():
                 print(f"Error deleting {file_path}: {e}")
         print("Unknown faces directory cleared.")
 
+
+def ensure_yunet_model():
+    """Download YuNet model if not present."""
+    os.makedirs(os.path.dirname(config.YUNET_MODEL_PATH), exist_ok=True)
+    if not os.path.exists(config.YUNET_MODEL_PATH):
+        import urllib.request
+
+        url = "https://github.com/opencv/opencv_zoo/raw/main/models/face_detection_yunet/face_detection_yunet_2023mar.onnx"
+        print("Downloading YuNet model...")
+        urllib.request.urlretrieve(url, config.YUNET_MODEL_PATH)
+        print(f"Downloaded to {config.YUNET_MODEL_PATH}")
+
+
+def create_yunet_detector():
+    """Create and configure YuNet face detector."""
+    ensure_yunet_model()
+    return cv2.FaceDetectorYN.create(
+        config.YUNET_MODEL_PATH,
+        "",
+        (config.DETECTION_WIDTH, config.DETECTION_HEIGHT),
+        score_threshold=config.YUNET_SCORE_THRESHOLD,
+        nms_threshold=config.YUNET_NMS_THRESHOLD,
+        top_k=5000,
+    )
+
+
+def map_face_to_original(face, det_w, det_h, orig_w, orig_h):
+    """Map YuNet detection from small frame to original coordinates with padding."""
+    x, y, w, h = face[0], face[1], face[2], face[3]
+    scale_x = orig_w / det_w
+    scale_y = orig_h / det_h
+
+    pad = config.FACE_CROP_PADDING
+    cx, cy = x + w / 2, y + h / 2
+    crop_w, crop_h = w * pad, h * pad
+
+    x1 = int(max(0, (cx - crop_w / 2) * scale_x))
+    y1 = int(max(0, (cy - crop_h / 2) * scale_y))
+    x2 = int(min(orig_w, (cx + crop_w / 2) * scale_x))
+    y2 = int(min(orig_h, (cy + crop_h / 2) * scale_y))
+
+    return x1, y1, x2, y2
+
+
+def process_frame_single_stage(frame, confirmation_buffer):
+    """Single-stage pipeline for low-res sources (webcam). DeepFace handles detection + embedding."""
+    processed_frame = normalize_frame(frame)
+
+    try:
+        result = extract_embedding(processed_frame)
+        if result is None:
+            return frame
+
+        embedding, face_data = result
+        name = handle_recognition(embedding, confirmation_buffer, frame)
+
+        region = face_data["facial_area"]
+        cv2.rectangle(
+            frame,
+            (region["x"], region["y"]),
+            (region["x"] + region["w"], region["y"] + region["h"]),
+            (0, 255, 0),
+            2,
+        )
+        cv2.putText(
+            frame, name, (region["x"], region["y"] - 10),
+            cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2,
+        )
+
+    except Exception as e:
+        print(f"Face processing error: {e}")
+
+    return frame
+
+
+def process_frame_two_stage(frame, yunet, confirmation_buffer):
+    """Two-stage pipeline for high-res sources (4K RTSP). YuNet detects, DeepFace embeds."""
+    orig_h, orig_w = frame.shape[:2]
+
+    detection_frame = cv2.resize(frame, (config.DETECTION_WIDTH, config.DETECTION_HEIGHT))
+    detection_frame = normalize_frame(detection_frame)
+
+    display_frame = cv2.resize(frame, (config.DISPLAY_WIDTH, config.DISPLAY_HEIGHT))
+    display_scale_x = config.DISPLAY_WIDTH / orig_w
+    display_scale_y = config.DISPLAY_HEIGHT / orig_h
+
+    _, faces_detected = yunet.detect(detection_frame)
+
+    if faces_detected is None:
+        return display_frame
+
+    for face in faces_detected:
+        try:
+            x1, y1, x2, y2 = map_face_to_original(
+                face, config.DETECTION_WIDTH, config.DETECTION_HEIGHT, orig_w, orig_h
+            )
+            face_crop = frame[y1:y2, x1:x2]
+            if face_crop.size == 0:
+                continue
+
+            result = extract_embedding(face_crop)
+            if result is None:
+                continue
+
+            embedding, _ = result
+            name = handle_recognition(embedding, confirmation_buffer, face_crop)
+
+            dx1 = int(x1 * display_scale_x)
+            dy1 = int(y1 * display_scale_y)
+            dx2 = int(x2 * display_scale_x)
+            dy2 = int(y2 * display_scale_y)
+            cv2.rectangle(display_frame, (dx1, dy1), (dx2, dy2), (0, 255, 0), 2)
+            cv2.putText(
+                display_frame, name, (dx1, dy1 - 10),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 255, 0), 2,
+            )
+
+        except Exception as e:
+            print(f"Face processing error: {e}")
+
+    return display_frame
+
+
 def main():
     global running
-    # Enhancement: Graceful exit via Ctrl+C
+    running = True
     signal.signal(signal.SIGINT, signal_handler)
 
     print(f"\n--- Face Attendance Monitoring ---")
@@ -89,82 +275,43 @@ def main():
         print(f"Error: Could not open camera {config.CAMERA_SOURCE}.")
         return
 
+    ret, frame = cap.read()
+    if not ret:
+        print("Error: Could not read first frame.")
+        cap.release()
+        return
+
+    orig_h, orig_w = frame.shape[:2]
+    use_two_stage = orig_w > config.DETECTION_WIDTH
+
+    yunet = None
+    if use_two_stage:
+        yunet = create_yunet_detector()
+        print(f"High-res source ({orig_w}x{orig_h}) — using two-stage YuNet pipeline")
+    else:
+        print(f"Low-res source ({orig_w}x{orig_h}) — using single-stage pipeline")
+
     confirmation_buffer = {"id": None, "count": 0}
 
     while running:
+        if use_two_stage:
+            display = process_frame_two_stage(frame, yunet, confirmation_buffer)
+        else:
+            display = process_frame_single_stage(frame, confirmation_buffer)
+
+        cv2.imshow("Face Attendance Monitoring", display)
+        if cv2.waitKey(1) & 0xFF == ord("q"):
+            running = False
+
         ret, frame = cap.read()
         if not ret:
             print("Error: Could not read frame.")
             break
 
-        processed_frame = normalize_frame(frame)
-
-        try:
-            faces = DeepFace.extract_faces(
-                img_path=processed_frame,
-                detector_backend=config.DETECTOR_BACKEND,
-                align=config.ALIGN,
-                enforce_detection=False
-            )
-
-            for face_data in faces:
-                if face_data['confidence'] < 0.6:
-                    continue
-
-                face_img = face_data['face']
-                results = DeepFace.represent(
-                    img_path=face_img,
-                    model_name=config.MODEL_NAME,
-                    detector_backend="skip",
-                    align=False,
-                    enforce_detection=False
-                )
-                
-                if not results:
-                    continue
-                
-                embedding = results[0]["embedding"]
-                member_id, name, distance = query_database(embedding)
-
-                if member_id:
-                    if confirmation_buffer["id"] == member_id:
-                        confirmation_buffer["count"] += 1
-                    else:
-                        confirmation_buffer["id"] = member_id
-                        confirmation_buffer["count"] = 1
-                    
-                    if confirmation_buffer["count"] >= config.CONFIRMATION_FRAMES:
-                        print(f"Confirmed match: {name} (Dist: {distance:.4f})")
-                        log_check_in(member_id)
-                        confirmation_buffer["count"] = 0
-                
-                elif distance is not None and distance >= config.RECOGNITION_THRESHOLD:
-                    print(f"Unknown face detected (Distance: {distance:.4f})")
-                    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                    image_filename = f"unknown_{timestamp}.jpg"
-                    image_path = os.path.join(config.UNKNOWN_FACES_DIR, image_filename)
-                    cv2.imwrite(image_path, frame)
-                    log_unknown_detection(embedding, image_path)
-                    confirmation_buffer["id"] = None
-                    confirmation_buffer["count"] = 0
-
-                # Feedback overlay
-                region = face_data['facial_area']
-                cv2.rectangle(frame, (region['x'], region['y']), (region['x']+region['w'], region['y']+region['h']), (0, 255, 0), 2)
-                cv2.putText(frame, f"{name}", (region['x'], region['y'] - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2)
-
-        except:
-            pass
-
-        cv2.imshow("Face Attendance Monitoring", frame)
-        if cv2.waitKey(1) & 0xFF == ord('q'):
-            running = False
-
     cap.release()
     cv2.destroyAllWindows()
-    
-    # Enhancement: Cleanup prompt
     cleanup_unknown()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,3 +19,11 @@ def mock_deepface_extract(mocker):
     """Common fixture to mock DeepFace.extract_faces."""
     mock_df_ext = mocker.patch("deepface.DeepFace.extract_faces")
     return mock_df_ext
+
+@pytest.fixture
+def mock_yunet(mocker):
+    """Mock YuNet detector for two-stage pipeline."""
+    mocker.patch("monitor.ensure_yunet_model")
+    mock_detector = MagicMock()
+    mocker.patch("cv2.FaceDetectorYN.create", return_value=mock_detector)
+    return mock_detector

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -4,43 +4,116 @@ import numpy as np
 import config
 from monitor import main as monitor_main
 
-def test_full_flow_success(mock_db_conn, mock_deepface, mock_deepface_extract, mocker):
+
+def test_full_flow_success(mock_db_conn, mock_deepface, mock_deepface_extract, mock_yunet, mocker):
     # Get mock connection and cursor from fixture
     mock_conn, mock_cur = mock_db_conn
-    
+
     # Mock camera to return one frame then exit
     mock_cap = mocker.patch("cv2.VideoCapture")
     mock_instance = mock_cap.return_value
     mock_instance.isOpened.return_value = True
-    
-    # Return a dummy frame once, then False to exit loop
-    dummy_frame = np.zeros((480, 640, 3), dtype=np.uint8)
+
+    # Return a dummy 4K frame once, then False to exit loop
+    dummy_frame = np.zeros((2160, 3840, 3), dtype=np.uint8)
     mock_instance.read.side_effect = [(True, dummy_frame), (False, None)]
-    
-    # Mock DeepFace.extract_faces to find one face
+
+    # Mock YuNet to detect one face at (100, 100, 50, 50) in detection frame coordinates
+    # YuNet returns array with shape (N, 15): x, y, w, h, landmarks..., score
+    face_detection = np.array([[100, 100, 50, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.95]], dtype=np.float32)
+    mock_yunet.detect.return_value = (1, face_detection)
+
+    # Mock DeepFace.extract_faces to find one face in the crop
     mock_deepface_extract.return_value = [{
-        'face': dummy_frame,
+        'face': np.zeros((160, 160, 3), dtype=np.float32),
         'facial_area': {'x': 0, 'y': 0, 'w': 10, 'h': 10},
         'confidence': 0.9
     }]
-    
+
     # Mock DeepFace.represent to return dummy embedding
     mock_deepface.return_value = [{"embedding": [0.1] * 512}]
-    
+
     # First query (query_database): Return a match
     # Second query (log_check_in -> cooldown check): Return None (no cooldown)
     mock_cur.fetchone.side_effect = [(101, "Test User", 0.1), None]
-    
-    # Mock cv2.imshow to avoid opening windows during test
+
+    # Mock cv2.imshow and resize to avoid GUI operations
     mocker.patch("cv2.imshow")
-    mocker.patch("cv2.waitKey", return_value=ord('q')) # Force exit
-    
-    # We need to mock CONFIRMATION_FRAMES to 1 for this test to trigger log_check_in quickly
+    mocker.patch("cv2.waitKey", return_value=ord('q'))
+    mocker.patch("cv2.destroyAllWindows")
+
+    # Set CONFIRMATION_FRAMES to 1 so log_check_in triggers on first match
     mocker.patch("config.CONFIRMATION_FRAMES", 1)
-    
+
     # Run the monitor main loop
     monitor_main()
-    
-    # Assertions
+
     # Verify log_check_in was reached (via DB call)
+    assert any("INSERT INTO attendance_log" in str(call) for call in mock_cur.execute.call_args_list)
+
+
+def test_no_faces_detected_skips_deepface(mock_db_conn, mock_deepface, mock_deepface_extract, mock_yunet, mocker):
+    """When YuNet detects no faces, DeepFace should not be called at all."""
+    mock_conn, mock_cur = mock_db_conn
+
+    mock_cap = mocker.patch("cv2.VideoCapture")
+    mock_instance = mock_cap.return_value
+    mock_instance.isOpened.return_value = True
+
+    dummy_frame = np.zeros((2160, 3840, 3), dtype=np.uint8)
+    mock_instance.read.side_effect = [(True, dummy_frame), (False, None)]
+
+    # YuNet detects no faces
+    mock_yunet.detect.return_value = (0, None)
+
+    mocker.patch("cv2.imshow")
+    mocker.patch("cv2.waitKey", return_value=ord('q'))
+    mocker.patch("cv2.destroyAllWindows")
+
+    monitor_main()
+
+    # DeepFace should never have been called
+    mock_deepface_extract.assert_not_called()
+    mock_deepface.assert_not_called()
+
+
+def test_single_stage_low_res(mock_db_conn, mock_deepface, mock_deepface_extract, mocker):
+    """Low-res webcam frames should use single-stage pipeline (no YuNet)."""
+    mock_conn, mock_cur = mock_db_conn
+
+    mock_cap = mocker.patch("cv2.VideoCapture")
+    mock_instance = mock_cap.return_value
+    mock_instance.isOpened.return_value = True
+
+    # 640x480 webcam frame — at or below DETECTION_WIDTH, triggers single-stage
+    dummy_frame = np.zeros((480, 640, 3), dtype=np.uint8)
+    mock_instance.read.side_effect = [(True, dummy_frame), (False, None)]
+
+    # Mock DeepFace.extract_faces to find one face
+    mock_deepface_extract.return_value = [{
+        'face': np.zeros((160, 160, 3), dtype=np.float32),
+        'facial_area': {'x': 0, 'y': 0, 'w': 10, 'h': 10},
+        'confidence': 0.9
+    }]
+
+    # Mock DeepFace.represent to return dummy embedding
+    mock_deepface.return_value = [{"embedding": [0.1] * 512}]
+
+    # DB returns a match, then no cooldown
+    mock_cur.fetchone.side_effect = [(101, "Test User", 0.1), None]
+
+    mocker.patch("cv2.imshow")
+    mocker.patch("cv2.waitKey", return_value=ord('q'))
+    mocker.patch("cv2.destroyAllWindows")
+    mocker.patch("config.CONFIRMATION_FRAMES", 1)
+
+    # YuNet should NOT be initialized — mock to verify it's never called
+    mock_yunet_create = mocker.patch("cv2.FaceDetectorYN.create")
+    mocker.patch("monitor.ensure_yunet_model")
+
+    monitor_main()
+
+    # YuNet should not have been used
+    mock_yunet_create.assert_not_called()
+    # But DeepFace should have processed the frame directly
     assert any("INSERT INTO attendance_log" in str(call) for call in mock_cur.execute.call_args_list)


### PR DESCRIPTION
Replace full-frame Haar cascade detection with a two-stage approach: YuNet on a downscaled 640x360 frame for fast face gating (~5ms), then DeepFace on cropped 4K regions for accurate embeddings. Auto-selects between two-stage (high-res) and single-stage (low-res webcam) pipelines based on the first frame's resolution.

- Add 8 env-configurable settings for detection/display dimensions and YuNet thresholds (config.py, .env.example)
- Replace bare except:pass with logged Exception handling
- Extract shared helpers: extract_embedding(), handle_recognition()
- Add mock_yunet test fixture and 3 new e2e tests covering both pipelines
- Exclude YuNet ONNX model from git (.gitignore)