### PR TITLE
feat: add dashboard based enrollment flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 A real-time automated attendance tracking system using facial recognition. Built with DeepFace, PostgreSQL (pgvector), and Flask.
 
 ## Features
-- **Real-time Recognition**: identify enrolled members via webcam or RTSP stream.
+- **Real-time Recognition**: Identify enrolled members via webcam or RTSP stream.
 - **pgvector Integration**: Efficient vector similarity search for face embeddings.
-- **Robust Enrollment**: Pre-checks DB connections and caches embeddings locally if the database is offline.
+- **Unknown Face Grouping**: Automatically groups unknown faces by embedding similarity so repeat visitors are linked together.
+- **Web Enrollment**: Review unknown face groups in the dashboard and enroll them with one click — no CLI needed.
+- **CLI Enrollment**: Batch-enroll from a folder of photos. `--folder` is optional and auto-generates from `--name`.
+- **Tabbed Dashboard**: Flask interface with an Attendance tab (check-in log with member photo thumbnails) and an Enroll tab (unknown face review queue).
+- **Member Photo Thumbnails**: Captures a face snapshot on first check-in and displays it in the attendance table.
 - **Smart Logging**: 3-frame confirmation logic to prevent false positives and configurable cool-down periods.
-- **Web Dashboard**: Simple Flask interface to view attendance logs in real-time.
-- **Unknown Face Capture**: Automatically logs and saves snapshots of unauthorized/unknown individuals.
+- **Offline Fallback**: Caches enrollment embeddings locally if the database is unreachable.
 
 ---
 
@@ -45,21 +48,35 @@ cp .env.example .env
 
 ## 🚀 How to Use
 
-### Step 1: Enroll Members
-Organize photos in `data/faces/your_name/` and run:
+### Option A: Web Enrollment (recommended)
+
+1. **Start the monitor** — detects faces and groups unknown visitors by similarity:
+   ```bash
+   uv run monitor.py
+   ```
+
+2. **Start the dashboard** (in a separate terminal):
+   ```bash
+   uv run app.py
+   ```
+
+3. **Enroll via the browser** — open http://localhost:5000, click the **Enroll** tab, enter a name for each unknown face group, and click Enroll.
+
+### Option B: CLI Enrollment
+
 ```bash
-uv run enroll.py --name "Your Name" --folder data/faces/your_name/
+# Auto-generate folder from name (creates data/faces/sdiviney/)
+uv run enroll.py --name "Sean Diviney"
+
+# Or specify an existing folder of photos
+uv run enroll.py --name "Sean Diviney" --folder data/faces/sdiviney/
 ```
 
-### Step 2: Run Monitoring
-Start the recognition loop:
+Then start the monitor and dashboard:
 ```bash
 uv run monitor.py
+uv run app.py     # http://localhost:5000
 ```
-*Note: The terminal will provide a link to the Web Log Viewer (usually http://localhost:5000).*
-
-### Step 3: View Logs
-Open your browser to the link provided by `monitor.py` to see the real-time check-in table.
 
 ---
 
@@ -81,11 +98,11 @@ Test results are saved in the `test_results/` directory using the format `{name_
 ---
 
 ## 📂 Project Structure
-- `enroll.py`: Script to add new faces to the DB.
-- `monitor.py`: The core recognition engine.
-- `app.py`: Flask web server for the log viewer.
-- `logger.py`: Database logic for check-ins and unknown faces.
-- `config.py`: Centralized configuration management.
+- `monitor.py`: Core recognition loop — face detection, embedding extraction, pgvector similarity search, unknown face grouping, member photo capture.
+- `enroll.py`: CLI enrollment — processes photos, averages embeddings, stores in DB. Auto-generates folder from name.
+- `app.py`: Flask dashboard — tabbed UI (Attendance + Enroll), serves member photos and unknown face snapshots.
+- `logger.py`: DB operations — check-in logging, unknown detection with group linking, web enrollment, member photo storage.
+- `config.py`: Centralized configuration from `.env`.
 - `bin/`: Setup and utility bash scripts.
 - `docs/`: Design plans, database schema, and user manuals.
 

--- a/app.py
+++ b/app.py
@@ -1,41 +1,60 @@
-from flask import Flask, render_template
-import psycopg2
+from datetime import datetime
+
+from flask import Flask, render_template, request, jsonify, send_from_directory
+
 import config
+from logger import (
+    get_attendance_logs,
+    get_unknown_groups,
+    enroll_from_unknown,
+    dismiss_unknown_group,
+)
 
 app = Flask(__name__)
 
-def get_db_connection():
-    return psycopg2.connect(
-        host=config.DB_HOST,
-        database=config.DB_NAME,
-        user=config.DB_USER,
-        password=config.DB_PASS,
-        port=config.DB_PORT
-    )
 
 @app.route('/')
 def index():
-    conn = None
-    logs = []
-    try:
-        conn = get_db_connection()
-        cur = conn.cursor()
-        # Fetch logs with member names
-        cur.execute(
-            "SELECT a.id, m.name, a.check_in_time "
-            "FROM attendance_log a "
-            "JOIN members m ON a.member_id = m.id "
-            "ORDER BY a.check_in_time DESC LIMIT 100"
-        )
-        logs = cur.fetchall()
-    except Exception as e:
-        print(f"Web error: {e}")
-    finally:
-        if conn:
-            conn.close()
-    
-    from datetime import datetime
-    return render_template('index.html', logs=logs, now=datetime.now())
+    logs = get_attendance_logs()
+    unknown_groups = get_unknown_groups()
+    return render_template('index.html', logs=logs, unknown_groups=unknown_groups, now=datetime.now())
+
+
+@app.route('/snapshots/<filename>')
+def serve_snapshot(filename):
+    return send_from_directory(config.UNKNOWN_FACES_DIR, filename)
+
+
+@app.route('/member-photos/<filename>')
+def serve_member_photo(filename):
+    return send_from_directory(config.MEMBER_FACES_DIR, filename)
+
+
+@app.route('/enroll', methods=['POST'])
+def enroll():
+    data = request.get_json()
+    if not data or not data.get('group_id') or not data.get('name', '').strip():
+        return jsonify({"error": "Missing name or group_id"}), 400
+
+    member_id = enroll_from_unknown(data['group_id'], data['name'].strip())
+    if member_id is None:
+        return jsonify({"error": "No detections found for group_id"}), 404
+
+    return jsonify({"success": True, "member_id": member_id, "name": data['name'].strip()})
+
+
+@app.route('/dismiss', methods=['POST'])
+def dismiss():
+    data = request.get_json()
+    if not data or not data.get('group_id'):
+        return jsonify({"error": "Missing group_id"}), 400
+
+    success = dismiss_unknown_group(data['group_id'])
+    if not success:
+        return jsonify({"error": "Failed to dismiss group"}), 500
+
+    return jsonify({"success": True})
+
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=config.FLASK_PORT, debug=True)

--- a/bin/setup_postgres.sh
+++ b/bin/setup_postgres.sh
@@ -63,7 +63,8 @@ CREATE TABLE IF NOT EXISTS members (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     face_embedding vector(512),
-    enrolled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    enrolled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    image_path TEXT
 );
 
 CREATE TABLE IF NOT EXISTS attendance_log (
@@ -76,7 +77,8 @@ CREATE TABLE IF NOT EXISTS unknown_detections (
     id SERIAL PRIMARY KEY,
     detected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     face_embedding vector(512),
-    image_path TEXT
+    image_path TEXT,
+    group_id UUID
 );
 EOF
 

--- a/config.py
+++ b/config.py
@@ -1,61 +1,54 @@
 import os
 from dotenv import load_dotenv
 
-# Load variables from .env if it exists
 load_dotenv()
 
-# Database Configuration
+
+def _env(name, default, cast=str):
+    """Read an env var, returning *default* when the var is missing or blank."""
+    val = os.getenv(name, "")
+    return cast(val) if val.strip() else default
+
+
+# Database
 DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_NAME = os.getenv("DB_NAME", "face_attendance")
 DB_USER = os.getenv("DB_USER", "postgres")
 DB_PASS = os.getenv("DB_PASS", "password")
 DB_PORT = os.getenv("DB_PORT", "5432")
 
-# Recognition Configuration
-RECOGNITION_THRESHOLD = float(os.getenv("RECOGNITION_THRESHOLD", "0.5"))
-CONFIRMATION_FRAMES = int(os.getenv("CONFIRMATION_FRAMES", "3"))
-CHECK_IN_COOLDOWN_MINUTES = int(os.getenv("CHECK_IN_COOLDOWN_MINUTES", "1"))
+# Recognition
+RECOGNITION_THRESHOLD = _env("RECOGNITION_THRESHOLD", 0.5, float)
+CONFIRMATION_FRAMES = _env("CONFIRMATION_FRAMES", 3, int)
+CHECK_IN_COOLDOWN_MINUTES = _env("CHECK_IN_COOLDOWN_MINUTES", 1, int)
 
-# File System Configuration
+# File system
 UNKNOWN_FACES_DIR = os.getenv("UNKNOWN_FACES_DIR", "data/unknown/")
 os.makedirs(UNKNOWN_FACES_DIR, exist_ok=True)
+MEMBER_FACES_DIR = os.getenv("MEMBER_FACES_DIR", "data/members/")
+os.makedirs(MEMBER_FACES_DIR, exist_ok=True)
 
-# Camera Configuration
-# If CAMERA_SOURCE is numeric, treat it as a camera index; otherwise, it's an RTSP/Video path.
-source = os.getenv("CAMERA_SOURCE", "0")
-if source.isdigit():
-    CAMERA_SOURCE = int(source)
-else:
-    CAMERA_SOURCE = source
+# Camera — numeric values are webcam indices, anything else is an RTSP/video path
+_camera_source = os.getenv("CAMERA_SOURCE", "0")
+CAMERA_SOURCE = int(_camera_source) if _camera_source.isdigit() else _camera_source
 
-# Web Configuration
-flask_port_str = os.getenv("FLASK_PORT", "5000")
-FLASK_PORT = int(flask_port_str) if flask_port_str.strip() else 5000
+# Web
+FLASK_PORT = _env("FLASK_PORT", 5000, int)
 
-# DeepFace Model Configuration
-# Facenet512 matches the 512-dimension vector in our DB schema
+# DeepFace — Facenet512 matches the 512-dimension vector in our DB schema
 MODEL_NAME = "Facenet512"
 DETECTOR_BACKEND = "opencv"
-# Don't raise an error if a face isn't clearly found in every frame
 ENFORCE_DETECTION = False
 ALIGN = True
 
-# Two-stage detection configuration
-def get_env_int(name, default):
-    val = os.getenv(name, "")
-    return int(val) if val.strip() else default
-
-def get_env_float(name, default):
-    val = os.getenv(name, "")
-    return float(val) if val.strip() else default
-
-DETECTION_WIDTH = get_env_int("DETECTION_WIDTH", 640)
-DETECTION_HEIGHT = get_env_int("DETECTION_HEIGHT", 360)
-DISPLAY_WIDTH = get_env_int("DISPLAY_WIDTH", 960)
-DISPLAY_HEIGHT = get_env_int("DISPLAY_HEIGHT", 540)
-YUNET_SCORE_THRESHOLD = get_env_float("YUNET_SCORE_THRESHOLD", 0.5)
-YUNET_NMS_THRESHOLD = get_env_float("YUNET_NMS_THRESHOLD", 0.3)
+# Two-stage detection
+DETECTION_WIDTH = _env("DETECTION_WIDTH", 640, int)
+DETECTION_HEIGHT = _env("DETECTION_HEIGHT", 360, int)
+DISPLAY_WIDTH = _env("DISPLAY_WIDTH", 960, int)
+DISPLAY_HEIGHT = _env("DISPLAY_HEIGHT", 540, int)
+YUNET_SCORE_THRESHOLD = _env("YUNET_SCORE_THRESHOLD", 0.5, float)
+YUNET_NMS_THRESHOLD = _env("YUNET_NMS_THRESHOLD", 0.3, float)
 YUNET_MODEL_PATH = os.path.join(os.path.dirname(__file__), "models", "face_detection_yunet_2023mar.onnx")
 
 # Face crop padding multiplier (1.5 = 50% padding around detected face)
-FACE_CROP_PADDING = get_env_float("FACE_CROP_PADDING", 1.5)
+FACE_CROP_PADDING = _env("FACE_CROP_PADDING", 1.5, float)

--- a/enroll.py
+++ b/enroll.py
@@ -1,25 +1,28 @@
 import argparse
-import os
-import psycopg2
 import json
+import os
+
 import numpy as np
+import psycopg2
 from deepface import DeepFace
+
 import config
+
 
 def get_connection():
     try:
-        conn = psycopg2.connect(
+        return psycopg2.connect(
             host=config.DB_HOST,
             database=config.DB_NAME,
             user=config.DB_USER,
             password=config.DB_PASS,
             port=config.DB_PORT,
-            connect_timeout=5
+            connect_timeout=5,
         )
-        return conn
     except Exception as e:
         print(f"Database connection failed: {e}")
         return None
+
 
 def extract_embedding(image_path):
     try:
@@ -28,7 +31,7 @@ def extract_embedding(image_path):
             model_name=config.MODEL_NAME,
             detector_backend=config.DETECTOR_BACKEND,
             align=config.ALIGN,
-            enforce_detection=True
+            enforce_detection=True,
         )
         if not results:
             return None
@@ -37,31 +40,31 @@ def extract_embedding(image_path):
         print(f"Error processing image {image_path}: {e}")
         return None
 
+
 def save_to_cache(name, embedding):
     cache_file = "enrollment_cache.json"
     cache_data = []
     if os.path.exists(cache_file):
         with open(cache_file, "r") as f:
             cache_data = json.load(f)
-    
+
     cache_data.append({"name": name, "embedding": embedding})
     with open(cache_file, "w") as f:
         json.dump(cache_data, f)
     print(f"Enrollment for {name} saved to local cache ({cache_file}).")
 
+
 def enroll_member(name, folder_path):
-    # Enhancement: Verify DB connection BEFORE work
     conn = get_connection()
     db_available = conn is not None
-    if not db_available:
-        print("Warning: Database not available. Progress will be cached locally.")
-    else:
+    if db_available:
         conn.close()
+    else:
+        print("Warning: Database not available. Progress will be cached locally.")
 
     embeddings = []
-    # Process all images in the folder
     for filename in os.listdir(folder_path):
-        if filename.lower().endswith(('.png', '.jpg', '.jpeg')):
+        if filename.lower().endswith((".png", ".jpg", ".jpeg")):
             image_path = os.path.join(folder_path, filename)
             print(f"Extracting embedding from {filename}...")
             embedding = extract_embedding(image_path)
@@ -72,31 +75,55 @@ def enroll_member(name, folder_path):
         print("Error: No faces could be extracted from the provided images.")
         return
 
-    # Average the embeddings
     avg_embedding = np.mean(embeddings, axis=0).tolist()
 
     if db_available:
+        conn = None
         try:
             conn = get_connection()
             cur = conn.cursor()
             cur.execute(
                 "INSERT INTO members (name, face_embedding) VALUES (%s, %s)",
-                (name, avg_embedding)
+                (name, avg_embedding),
             )
             conn.commit()
             print(f"Successfully enrolled member: {name}")
-            conn.close()
             return
         except Exception as e:
             print(f"Error saving to database: {e}")
-    
-    # Enhancement: Cache if DB fails or is unavailable
+        finally:
+            if conn:
+                conn.close()
+
     save_to_cache(name, avg_embedding)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Enroll a new member into the Face Attendance system.")
     parser.add_argument("--name", required=True, help="Full name of the member")
-    parser.add_argument("--folder", required=True, help="Path to a folder containing photos of the member")
-    
+    parser.add_argument("--folder", required=False, default=None, help="Path to a folder containing photos of the member")
+
     args = parser.parse_args()
-    enroll_member(args.name, args.folder)
+
+    if args.folder:
+        # Explicit folder provided — must exist
+        if not os.path.isdir(args.folder):
+            print(f"Error: Folder not found: {args.folder}. Create it and add photos first.")
+            exit(1)
+        enroll_member(args.name, args.folder)
+    else:
+        # Auto-generate folder from name
+        parts = args.name.strip().split()
+        first_name = parts[0].lower()
+        last_name = parts[-1].lower() if len(parts) > 1 else first_name
+
+        folder_name = f"{first_name[0]}{last_name}"
+        folder_path = os.path.join("data", "faces", folder_name)
+
+        if os.path.exists(folder_path):
+            folder_name = f"{first_name[:2]}{last_name}"
+            folder_path = os.path.join("data", "faces", folder_name)
+
+        os.makedirs(folder_path, exist_ok=True)
+        print(f"Created folder: {folder_path}/ - Add photos and re-run, or press Enter to continue if photos are already there.")
+        input()
+        enroll_member(args.name, folder_path)

--- a/logger.py
+++ b/logger.py
@@ -1,6 +1,13 @@
-import psycopg2
+import json
+import os
+from contextlib import contextmanager
 from datetime import datetime, timedelta
+
+import numpy as np
+import psycopg2
+
 import config
+
 
 def get_connection():
     return psycopg2.connect(
@@ -8,62 +15,212 @@ def get_connection():
         database=config.DB_NAME,
         user=config.DB_USER,
         password=config.DB_PASS,
-        port=config.DB_PORT
+        port=config.DB_PORT,
     )
 
-def log_check_in(member_id):
-    conn = None
+
+@contextmanager
+def _db_cursor(*, commit=False):
+    """Yield a DB cursor, optionally committing on success.
+
+    Rolls back on exception, always closes the connection.
+    """
+    conn = get_connection()
     try:
-        conn = get_connection()
         cur = conn.cursor()
+        yield cur
+        if commit:
+            conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
 
-        # Check for cool-down
-        cooldown_time = datetime.now() - timedelta(minutes=config.CHECK_IN_COOLDOWN_MINUTES)
-        cur.execute(
-            "SELECT id FROM attendance_log WHERE member_id = %s AND check_in_time > %s LIMIT 1",
-            (member_id, cooldown_time)
-        )
-        already_logged = cur.fetchone()
 
-        if already_logged:
-            print(f"Skipping check-in for member {member_id} due to cool-down.")
-            return False
+def log_check_in(member_id):
+    try:
+        with _db_cursor(commit=True) as cur:
+            cooldown_time = datetime.now() - timedelta(minutes=config.CHECK_IN_COOLDOWN_MINUTES)
+            cur.execute(
+                "SELECT id FROM attendance_log WHERE member_id = %s AND check_in_time > %s LIMIT 1",
+                (member_id, cooldown_time),
+            )
 
-        # Perform check-in
-        cur.execute(
-            "INSERT INTO attendance_log (member_id) VALUES (%s)",
-            (member_id,)
-        )
-        conn.commit()
-        print(f"Successfully logged check-in for member {member_id}.")
-        return True
+            if cur.fetchone():
+                print(f"Skipping check-in for member {member_id} due to cool-down.")
+                return False
 
+            cur.execute(
+                "INSERT INTO attendance_log (member_id) VALUES (%s)",
+                (member_id,),
+            )
+            print(f"Successfully logged check-in for member {member_id}.")
+            return True
     except Exception as e:
         print(f"Database error during check-in: {e}")
         return False
-    finally:
-        if conn:
-            conn.close()
 
-def log_unknown_detection(embedding, image_path):
-    conn = None
+
+def save_member_image(member_id, image_path):
+    """Save member photo path, only if they don't already have one."""
     try:
-        conn = get_connection()
-        cur = conn.cursor()
-        
-        # Convert list/numpy array embedding to list for pgvector (it accepts list format as [1,2,...])
-        embedding_list = list(embedding)
-        
-        cur.execute(
-            "INSERT INTO unknown_detections (face_embedding, image_path) VALUES (%s, %s)",
-            (embedding_list, image_path)
-        )
-        conn.commit()
-        print(f"Logged unknown detection at {image_path}.")
-        return True
+        with _db_cursor(commit=True) as cur:
+            cur.execute(
+                "UPDATE members SET image_path = %s WHERE id = %s AND image_path IS NULL",
+                (image_path, member_id),
+            )
+            return cur.rowcount > 0
+    except Exception as e:
+        print(f"Error saving member image: {e}")
+        return False
+
+
+def log_unknown_detection(embedding, image_path, group_id=None):
+    try:
+        with _db_cursor(commit=True) as cur:
+            cur.execute(
+                "INSERT INTO unknown_detections (face_embedding, image_path, group_id) VALUES (%s, %s, %s)",
+                (list(embedding), image_path, group_id),
+            )
+            print(f"Logged unknown detection at {image_path}.")
+            return True
     except Exception as e:
         print(f"Error logging unknown detection: {e}")
         return False
-    finally:
-        if conn:
-            conn.close()
+
+
+def find_matching_unknown_group(embedding):
+    """Find an existing unknown group that matches this embedding."""
+    try:
+        with _db_cursor() as cur:
+            cur.execute(
+                "SELECT group_id, face_embedding <=> %s::vector AS distance "
+                "FROM unknown_detections "
+                "WHERE group_id IS NOT NULL "
+                "ORDER BY distance ASC LIMIT 1",
+                (list(embedding),),
+            )
+            result = cur.fetchone()
+            if result and result[1] < config.RECOGNITION_THRESHOLD:
+                return result[0]
+            return None
+    except Exception as e:
+        print(f"Error finding unknown group: {e}")
+        return None
+
+
+def get_unknown_groups():
+    """Get summary of unknown face groups for the dashboard."""
+    try:
+        with _db_cursor() as cur:
+            cur.execute(
+                "SELECT ud.group_id, MIN(ud.image_path) AS image_path, "
+                "COUNT(*) AS seen_count, "
+                "MIN(ud.detected_at) AS first_seen, "
+                "MAX(ud.detected_at) AS last_seen "
+                "FROM unknown_detections ud "
+                "WHERE ud.group_id IS NOT NULL "
+                "GROUP BY ud.group_id "
+                "ORDER BY MAX(ud.detected_at) DESC"
+            )
+            return cur.fetchall()
+    except Exception as e:
+        print(f"Error fetching unknown groups: {e}")
+        return []
+
+
+def get_attendance_logs(limit=100):
+    """Fetch recent attendance logs with member info for the dashboard."""
+    try:
+        with _db_cursor() as cur:
+            cur.execute(
+                "SELECT m.image_path, m.name, a.check_in_time "
+                "FROM attendance_log a "
+                "JOIN members m ON a.member_id = m.id "
+                "ORDER BY a.check_in_time DESC LIMIT %s",
+                (limit,),
+            )
+            return cur.fetchall()
+    except Exception as e:
+        print(f"Error fetching attendance logs: {e}")
+        return []
+
+
+def _delete_snapshot_files(image_paths):
+    """Remove snapshot image files from disk, ignoring missing files."""
+    for path in image_paths:
+        try:
+            if path and os.path.isfile(path):
+                os.unlink(path)
+        except OSError:
+            pass
+
+
+def _get_group_image_paths(cur, group_id):
+    """Fetch all image_path values for a given unknown detection group."""
+    cur.execute(
+        "SELECT image_path FROM unknown_detections WHERE group_id = %s",
+        (group_id,),
+    )
+    return [row[0] for row in cur.fetchall()]
+
+
+def _parse_embedding(value):
+    """Parse an embedding from pgvector, which may be a string or a list."""
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def enroll_from_unknown(group_id, name):
+    """Enroll a member from unknown detection group. Returns member_id or None."""
+    try:
+        with _db_cursor(commit=True) as cur:
+            cur.execute(
+                "SELECT face_embedding FROM unknown_detections WHERE group_id = %s",
+                (group_id,),
+            )
+            rows = cur.fetchall()
+            if not rows:
+                return None
+
+            embeddings = [np.array(_parse_embedding(row[0])) for row in rows]
+            avg_embedding = np.mean(embeddings, axis=0).tolist()
+
+            cur.execute(
+                "INSERT INTO members (name, face_embedding) VALUES (%s, %s) RETURNING id",
+                (name, avg_embedding),
+            )
+            member_id = cur.fetchone()[0]
+
+            image_paths = _get_group_image_paths(cur, group_id)
+
+            cur.execute(
+                "DELETE FROM unknown_detections WHERE group_id = %s",
+                (group_id,),
+            )
+
+        _delete_snapshot_files(image_paths)
+        return member_id
+    except Exception as e:
+        print(f"Error enrolling from unknown: {e}")
+        return None
+
+
+def dismiss_unknown_group(group_id):
+    """Delete an unknown group and its snapshots. Returns True on success."""
+    try:
+        with _db_cursor(commit=True) as cur:
+            image_paths = _get_group_image_paths(cur, group_id)
+
+            cur.execute(
+                "DELETE FROM unknown_detections WHERE group_id = %s",
+                (group_id,),
+            )
+
+        _delete_snapshot_files(image_paths)
+        return True
+    except Exception as e:
+        print(f"Error dismissing unknown group: {e}")
+        return False

--- a/monitor.py
+++ b/monitor.py
@@ -1,40 +1,23 @@
 import os
-import signal
 import threading
+import uuid
 from datetime import datetime
 
 import cv2
 import numpy as np
-import psycopg2
 from deepface import DeepFace
 
 import config
 from app import app
-from logger import log_check_in, log_unknown_detection
+from logger import (
+    get_connection,
+    find_matching_unknown_group,
+    log_check_in,
+    log_unknown_detection,
+    save_member_image,
+)
 
 FACE_CONFIDENCE_THRESHOLD = 0.6
-
-running = True
-
-
-def signal_handler(sig, frame):
-    global running
-    print("\nStopping monitoring...")
-    running = False
-
-
-def get_connection():
-    try:
-        return psycopg2.connect(
-            host=config.DB_HOST,
-            database=config.DB_NAME,
-            user=config.DB_USER,
-            password=config.DB_PASS,
-            port=config.DB_PORT,
-            connect_timeout=5,
-        )
-    except Exception:
-        return None
 
 
 def normalize_frame(frame):
@@ -46,8 +29,9 @@ def normalize_frame(frame):
 
 def query_database(embedding):
     """Find the closest member by cosine distance. Returns (member_id, name, distance)."""
-    conn = get_connection()
-    if not conn:
+    try:
+        conn = get_connection()
+    except Exception:
         return None, "DB Error", None
     try:
         cur = conn.cursor()
@@ -107,15 +91,27 @@ def handle_recognition(embedding, confirmation_buffer, image_to_save):
 
         if confirmation_buffer["count"] >= config.CONFIRMATION_FRAMES:
             print(f"Confirmed match: {name} (Dist: {distance:.4f})")
-            log_check_in(member_id)
+            checked_in = log_check_in(member_id)
+            if checked_in:
+                image_path = os.path.join(config.MEMBER_FACES_DIR, f"member_{member_id}.jpg")
+                if not os.path.exists(image_path):
+                    cv2.imwrite(image_path, image_to_save)
+                    save_member_image(member_id, image_path)
             confirmation_buffer["count"] = 0
 
-    elif distance is not None and distance >= config.RECOGNITION_THRESHOLD:
-        print(f"Unknown face detected (Distance: {distance:.4f})")
+    elif name == "Unknown":
+        group_id = find_matching_unknown_group(embedding)
+        if group_id is None:
+            group_id = str(uuid.uuid4())
+
+        if distance is not None:
+            print(f"Unknown face detected (Distance: {distance:.4f})")
+        else:
+            print("Unknown face detected (no members enrolled)")
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         image_path = os.path.join(config.UNKNOWN_FACES_DIR, f"unknown_{timestamp}.jpg")
         cv2.imwrite(image_path, image_to_save)
-        log_unknown_detection(embedding, image_path)
+        log_unknown_detection(embedding, image_path, group_id)
         confirmation_buffer["id"] = None
         confirmation_buffer["count"] = 0
 
@@ -168,7 +164,7 @@ def create_yunet_detector():
 
 def map_face_to_original(face, det_w, det_h, orig_w, orig_h):
     """Map YuNet detection from small frame to original coordinates with padding."""
-    x, y, w, h = face[0], face[1], face[2], face[3]
+    x, y, w, h = face[:4]
     scale_x = orig_w / det_w
     scale_y = orig_h / det_h
 
@@ -272,18 +268,16 @@ def start_web_server():
 
 
 def main():
-    global running
-    running = True
-    signal.signal(signal.SIGINT, signal_handler)
-
-    # Start Flask dashboard in the background
     web_thread = threading.Thread(target=start_web_server, daemon=True)
     web_thread.start()
 
-    print(f"\n--- Face Attendance Monitoring ---")
+    print("\n--- Face Attendance Monitoring ---")
     print(f"Log Viewer available at: http://localhost:{config.FLASK_PORT}")
-    print(f"Press 'q' in the camera window or Ctrl+C to exit.\n")
+    print("Press 'q' in the camera window or Ctrl+C to exit.\n")
+
     cap = cv2.VideoCapture(config.CAMERA_SOURCE)
+    cap.set(cv2.CAP_PROP_OPEN_TIMEOUT_MSEC, 5000)
+    cap.set(cv2.CAP_PROP_READ_TIMEOUT_MSEC, 5000)
     if not cap.isOpened():
         print(f"Error: Could not open camera {config.CAMERA_SOURCE}.")
         return
@@ -305,21 +299,25 @@ def main():
         print(f"Low-res source ({orig_w}x{orig_h}) — using single-stage pipeline")
 
     confirmation_buffer = {"id": None, "count": 0}
+    running = True
 
-    while running:
-        if use_two_stage:
-            display = process_frame_two_stage(frame, yunet, confirmation_buffer)
-        else:
-            display = process_frame_single_stage(frame, confirmation_buffer)
+    try:
+        while running:
+            if use_two_stage:
+                display = process_frame_two_stage(frame, yunet, confirmation_buffer)
+            else:
+                display = process_frame_single_stage(frame, confirmation_buffer)
 
-        cv2.imshow("Face Attendance Monitoring", display)
-        if cv2.waitKey(1) & 0xFF == ord("q"):
-            running = False
+            cv2.imshow("Face Attendance Monitoring", display)
+            if cv2.waitKey(1) & 0xFF == ord("q"):
+                running = False
 
-        ret, frame = cap.read()
-        if not ret:
-            print("Error: Could not read frame.")
-            break
+            ret, frame = cap.read()
+            if not ret:
+                print("Error: Could not read frame.")
+                break
+    except KeyboardInterrupt:
+        print("\nStopping monitoring...")
 
     cap.release()
     cv2.destroyAllWindows()

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,52 +3,162 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Face Attendance Logs</title>
+    <title>Face Attendance</title>
     <meta http-equiv="refresh" content="30">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
         body { background-color: #f8f9fa; }
-        .container { margin-top: 50px; }
-        .header { margin-bottom: 30px; border-bottom: 2px solid #dee2e6; padding-bottom: 15px; }
+        .container { margin-top: 30px; }
+        .header { margin-bottom: 20px; border-bottom: 2px solid #dee2e6; padding-bottom: 15px; }
+        .unknown-card img { width: 100%; height: 200px; object-fit: cover; border-radius: 4px; }
+        .unknown-card { margin-bottom: 20px; }
     </style>
 </head>
 <body>
     <div class="container">
         <div class="header">
-            <h1 class="display-4">Attendance Logs</h1>
-            <p class="lead">Latest check-in events from the monitoring system.</p>
+            <h1 class="display-4">Face Attendance</h1>
         </div>
-        
-        <div class="table-responsive">
-            <table class="table table-striped table-hover shadow-sm">
-                <thead class="table-dark">
-                    <tr>
-                        <th>ID</th>
-                        <th>Member Name</th>
-                        <th>Check-in Time</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% if logs %}
-                        {% for log in logs %}
-                        <tr>
-                            <td>{{ log[0] }}</td>
-                            <td><strong>{{ log[1] }}</strong></td>
-                            <td>{{ log[2].strftime('%Y-%m-%d %H:%M:%S') }}</td>
-                        </tr>
-                        {% endfor %}
-                    {% else %}
-                        <tr>
-                            <td colspan="3" class="text-center text-muted">No logs found. Try checking in at the camera!</td>
-                        </tr>
+
+        <ul class="nav nav-tabs mb-4" id="mainTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="attendance-tab" data-bs-toggle="tab" data-bs-target="#attendance" type="button" role="tab">Attendance</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="enroll-tab" data-bs-toggle="tab" data-bs-target="#enroll" type="button" role="tab">
+                    Enroll
+                    {% if unknown_groups %}
+                        <span class="badge bg-danger">{{ unknown_groups|length }}</span>
                     {% endif %}
-                </tbody>
-            </table>
+                </button>
+            </li>
+        </ul>
+
+        <div class="tab-content" id="mainTabContent">
+            <!-- Attendance Tab -->
+            <div class="tab-pane fade show active" id="attendance" role="tabpanel">
+                <div class="table-responsive">
+                    <table class="table table-striped table-hover shadow-sm">
+                        <thead class="table-dark">
+                            <tr>
+                                <th style="width: 60px;">Photo</th>
+                                <th>Member Name</th>
+                                <th>Check-in Time</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% if logs %}
+                                {% for log in logs %}
+                                <tr>
+                                    <td>
+                                        {% if log[0] %}
+                                        <img src="/member-photos/{{ log[0].split('/')[-1] }}" style="width: 48px; height: 48px; object-fit: cover; border-radius: 50%;">
+                                        {% else %}
+                                        <span class="text-muted">--</span>
+                                        {% endif %}
+                                    </td>
+                                    <td><strong>{{ log[1] }}</strong></td>
+                                    <td>{{ log[2].strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                                </tr>
+                                {% endfor %}
+                            {% else %}
+                                <tr>
+                                    <td colspan="3" class="text-center text-muted">No logs found. Try checking in at the camera!</td>
+                                </tr>
+                            {% endif %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Enroll Tab -->
+            <div class="tab-pane fade" id="enroll" role="tabpanel">
+                {% if unknown_groups %}
+                    <div class="row">
+                        {% for group in unknown_groups %}
+                        <div class="col-md-4 col-lg-3">
+                            <div class="card unknown-card shadow-sm">
+                                <img src="/snapshots/{{ group[1].split('/')[-1] }}" class="card-img-top" alt="Unknown face">
+                                <div class="card-body">
+                                    <p class="card-text mb-1">
+                                        <strong>Seen:</strong> {{ group[2] }} time{{ 's' if group[2] != 1 else '' }}
+                                    </p>
+                                    <p class="card-text mb-1">
+                                        <small class="text-muted">First: {{ group[3].strftime('%I:%M %p') }}</small>
+                                    </p>
+                                    {% if group[2] > 1 %}
+                                    <p class="card-text mb-2">
+                                        <small class="text-muted">Last: {{ group[4].strftime('%I:%M %p') }}</small>
+                                    </p>
+                                    {% endif %}
+                                    <div class="input-group mb-2">
+                                        <input type="text" class="form-control form-control-sm" placeholder="Name" id="name-{{ group[0] }}">
+                                    </div>
+                                    <div class="d-flex gap-2">
+                                        <button class="btn btn-success btn-sm flex-fill" onclick="enrollFace('{{ group[0] }}')">Enroll</button>
+                                        <button class="btn btn-outline-danger btn-sm flex-fill" onclick="dismissFace('{{ group[0] }}')">Dismiss</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    <div class="text-center text-muted py-5">
+                        <p>No unknown faces detected yet.</p>
+                    </div>
+                {% endif %}
+            </div>
         </div>
-        
+
         <div class="mt-4 text-center text-muted">
             <small>Refreshing every 30 seconds... (Last updated: {{ now.strftime('%H:%M:%S') }})</small>
         </div>
     </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        function enrollFace(groupId) {
+            const nameInput = document.getElementById('name-' + groupId);
+            const name = nameInput.value.trim();
+            if (!name) {
+                nameInput.classList.add('is-invalid');
+                return;
+            }
+            nameInput.classList.remove('is-invalid');
+
+            fetch('/enroll', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ group_id: groupId, name: name })
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    alert('Error: ' + (data.error || 'Unknown error'));
+                }
+            })
+            .catch(err => alert('Request failed: ' + err));
+        }
+
+        function dismissFace(groupId) {
+            fetch('/dismiss', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ group_id: groupId })
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    alert('Error: ' + (data.error || 'Unknown error'));
+                }
+            })
+            .catch(err => alert('Request failed: ' + err));
+        }
+    </script>
 </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,29 +1,30 @@
 import pytest
-from unittest.mock import MagicMock
+
 
 @pytest.fixture
 def mock_db_conn(mocker):
-    """Common fixture to mock psycopg2 database connection."""
-    mock_conn = mocker.patch("psycopg2.connect")
-    mock_cur = mock_conn.return_value.cursor.return_value
-    return mock_conn, mock_cur
+    """Mock psycopg2.connect, returning (mock_connect, mock_cursor)."""
+    mock_connect = mocker.patch("psycopg2.connect")
+    mock_cursor = mock_connect.return_value.cursor.return_value
+    return mock_connect, mock_cursor
+
 
 @pytest.fixture
 def mock_deepface(mocker):
-    """Common fixture to mock DeepFace.represent."""
-    mock_df = mocker.patch("deepface.DeepFace.represent")
-    return mock_df
+    """Mock DeepFace.represent."""
+    return mocker.patch("deepface.DeepFace.represent")
+
 
 @pytest.fixture
 def mock_deepface_extract(mocker):
-    """Common fixture to mock DeepFace.extract_faces."""
-    mock_df_ext = mocker.patch("deepface.DeepFace.extract_faces")
-    return mock_df_ext
+    """Mock DeepFace.extract_faces."""
+    return mocker.patch("deepface.DeepFace.extract_faces")
+
 
 @pytest.fixture
 def mock_yunet(mocker):
     """Mock YuNet detector for two-stage pipeline."""
     mocker.patch("monitor.ensure_yunet_model")
-    mock_detector = MagicMock()
+    mock_detector = mocker.MagicMock()
     mocker.patch("cv2.FaceDetectorYN.create", return_value=mock_detector)
     return mock_detector

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,8 @@
 import pytest
-from app import app
 from datetime import datetime
+
+from app import app
+
 
 @pytest.fixture
 def client():
@@ -8,29 +10,123 @@ def client():
     with app.test_client() as client:
         yield client
 
-def test_index_route(client, mock_db_conn):
-    # Get mock connection and cursor from fixture
-    mock_conn, mock_cur = mock_db_conn
-    
-    # Mock some attendance logs
-    mock_cur.fetchall.return_value = [
-        (1, "John Doe", datetime(2023, 10, 27, 10, 0, 0)),
-        (2, "Jane Smith", datetime(2023, 10, 27, 10, 5, 0))
-    ]
-    
+
+def test_index_route(client, mocker):
+    mocker.patch("app.get_attendance_logs", return_value=[
+        ("data/members/member_1.jpg", "John Doe", datetime(2023, 10, 27, 10, 0, 0)),
+        ("data/members/member_2.jpg", "Jane Smith", datetime(2023, 10, 27, 10, 5, 0)),
+    ])
+    mocker.patch("app.get_unknown_groups", return_value=[])
+
     response = client.get('/')
     assert response.status_code == 200
-    
-    # Check if the content contains the names from our mock
     assert b"John Doe" in response.data
     assert b"Jane Smith" in response.data
-    assert b"Attendance Logs" in response.data
+    assert b"Face Attendance" in response.data
 
-def test_index_no_logs(client, mock_db_conn):
-    # Get mock connection and cursor from fixture
-    mock_conn, mock_cur = mock_db_conn
-    mock_cur.fetchall.return_value = []
-    
+
+def test_index_no_logs(client, mocker):
+    mocker.patch("app.get_attendance_logs", return_value=[])
+    mocker.patch("app.get_unknown_groups", return_value=[])
+
     response = client.get('/')
     assert response.status_code == 200
     assert b"No logs found" in response.data
+
+
+def test_enroll_success(client, mocker):
+    mocker.patch("app.enroll_from_unknown", return_value=42)
+
+    response = client.post('/enroll',
+        json={"group_id": "abc-123", "name": "John Doe"})
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert data["member_id"] == 42
+    assert data["name"] == "John Doe"
+
+
+def test_enroll_missing_name(client, mocker):
+    response = client.post('/enroll', json={"group_id": "abc-123"})
+    assert response.status_code == 400
+
+
+def test_enroll_missing_group_id(client, mocker):
+    response = client.post('/enroll', json={"name": "John Doe"})
+    assert response.status_code == 400
+
+
+def test_enroll_group_not_found(client, mocker):
+    mocker.patch("app.enroll_from_unknown", return_value=None)
+
+    response = client.post('/enroll',
+        json={"group_id": "nonexistent", "name": "John Doe"})
+
+    assert response.status_code == 404
+
+
+def test_dismiss_success(client, mocker):
+    mocker.patch("app.dismiss_unknown_group", return_value=True)
+
+    response = client.post('/dismiss', json={"group_id": "abc-123"})
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+
+
+def test_dismiss_missing_group_id(client, mocker):
+    response = client.post('/dismiss', json={})
+    assert response.status_code == 400
+
+
+def test_dismiss_failure(client, mocker):
+    mocker.patch("app.dismiss_unknown_group", return_value=False)
+
+    response = client.post('/dismiss', json={"group_id": "abc-123"})
+
+    assert response.status_code == 500
+
+
+def test_serve_member_photo(client, mocker, tmp_path):
+    photo = tmp_path / "member_1.jpg"
+    photo.write_bytes(b"\xff\xd8fake-jpeg")
+    mocker.patch("app.config.MEMBER_FACES_DIR", str(tmp_path))
+
+    response = client.get('/member-photos/member_1.jpg')
+    assert response.status_code == 200
+    assert response.data == b"\xff\xd8fake-jpeg"
+
+
+def test_serve_member_photo_not_found(client, mocker, tmp_path):
+    mocker.patch("app.config.MEMBER_FACES_DIR", str(tmp_path))
+
+    response = client.get('/member-photos/nonexistent.jpg')
+    assert response.status_code == 404
+
+
+def test_index_renders_member_photo(client, mocker):
+    mocker.patch("app.get_attendance_logs", return_value=[
+        ("data/members/member_1.jpg", "John Doe", datetime(2023, 10, 27, 10, 0, 0)),
+        (None, "Jane Smith", datetime(2023, 10, 27, 10, 5, 0)),
+    ])
+    mocker.patch("app.get_unknown_groups", return_value=[])
+
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b'/member-photos/member_1.jpg' in response.data
+    assert b'text-muted' in response.data  # placeholder for Jane (no photo)
+
+
+def test_index_with_unknown_groups(client, mocker):
+    mocker.patch("app.get_attendance_logs", return_value=[])
+    mocker.patch("app.get_unknown_groups", return_value=[
+        ("group-uuid-1", "data/unknown/unknown_20231027_100000.jpg", 3,
+         datetime(2023, 10, 27, 10, 0, 0), datetime(2023, 10, 27, 10, 15, 0)),
+    ])
+
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b"Enroll" in response.data
+    assert b"3 times" in response.data

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,8 +1,7 @@
-import pytest
-import cv2
 import numpy as np
-import config
-from monitor import main as monitor_main
+import pytest
+
+from monitor import main as monitor_main, handle_recognition
 
 
 @pytest.fixture(autouse=True)
@@ -14,55 +13,43 @@ def mock_monitor_infra(mocker):
 
 
 def test_full_flow_success(mock_db_conn, mock_deepface, mock_deepface_extract, mock_yunet, mocker):
-    # Get mock connection and cursor from fixture
-    mock_conn, mock_cur = mock_db_conn
+    _mock_connect, mock_cur = mock_db_conn
 
-    # Mock camera to return one frame then exit
     mock_cap = mocker.patch("cv2.VideoCapture")
     mock_instance = mock_cap.return_value
     mock_instance.isOpened.return_value = True
 
-    # Return a dummy 4K frame once, then False to exit loop
     dummy_frame = np.zeros((2160, 3840, 3), dtype=np.uint8)
     mock_instance.read.side_effect = [(True, dummy_frame), (False, None)]
 
-    # Mock YuNet to detect one face at (100, 100, 50, 50) in detection frame coordinates
     # YuNet returns array with shape (N, 15): x, y, w, h, landmarks..., score
     face_detection = np.array([[100, 100, 50, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.95]], dtype=np.float32)
     mock_yunet.detect.return_value = (1, face_detection)
 
-    # Mock DeepFace.extract_faces to find one face in the crop
     mock_deepface_extract.return_value = [{
         'face': np.zeros((160, 160, 3), dtype=np.float32),
         'facial_area': {'x': 0, 'y': 0, 'w': 10, 'h': 10},
-        'confidence': 0.9
+        'confidence': 0.9,
     }]
-
-    # Mock DeepFace.represent to return dummy embedding
     mock_deepface.return_value = [{"embedding": [0.1] * 512}]
 
-    # First query (query_database): Return a match
-    # Second query (log_check_in -> cooldown check): Return None (no cooldown)
+    # First: query_database match; Second: log_check_in cooldown check (none found)
     mock_cur.fetchone.side_effect = [(101, "Test User", 0.1), None]
 
-    # Mock cv2.imshow and resize to avoid GUI operations
     mocker.patch("cv2.imshow")
+    mocker.patch("cv2.imwrite")
     mocker.patch("cv2.waitKey", return_value=ord('q'))
     mocker.patch("cv2.destroyAllWindows")
-
-    # Set CONFIRMATION_FRAMES to 1 so log_check_in triggers on first match
     mocker.patch("config.CONFIRMATION_FRAMES", 1)
 
-    # Run the monitor main loop
     monitor_main()
 
-    # Verify log_check_in was reached (via DB call)
     assert any("INSERT INTO attendance_log" in str(call) for call in mock_cur.execute.call_args_list)
 
 
 def test_no_faces_detected_skips_deepface(mock_db_conn, mock_deepface, mock_deepface_extract, mock_yunet, mocker):
     """When YuNet detects no faces, DeepFace should not be called at all."""
-    mock_conn, mock_cur = mock_db_conn
+    _mock_connect, _mock_cur = mock_db_conn
 
     mock_cap = mocker.patch("cv2.VideoCapture")
     mock_instance = mock_cap.return_value
@@ -71,7 +58,6 @@ def test_no_faces_detected_skips_deepface(mock_db_conn, mock_deepface, mock_deep
     dummy_frame = np.zeros((2160, 3840, 3), dtype=np.uint8)
     mock_instance.read.side_effect = [(True, dummy_frame), (False, None)]
 
-    # YuNet detects no faces
     mock_yunet.detect.return_value = (0, None)
 
     mocker.patch("cv2.imshow")
@@ -80,48 +66,82 @@ def test_no_faces_detected_skips_deepface(mock_db_conn, mock_deepface, mock_deep
 
     monitor_main()
 
-    # DeepFace should never have been called
     mock_deepface_extract.assert_not_called()
     mock_deepface.assert_not_called()
 
 
 def test_single_stage_low_res(mock_db_conn, mock_deepface, mock_deepface_extract, mocker):
     """Low-res webcam frames should use single-stage pipeline (no YuNet)."""
-    mock_conn, mock_cur = mock_db_conn
+    _mock_connect, mock_cur = mock_db_conn
 
     mock_cap = mocker.patch("cv2.VideoCapture")
     mock_instance = mock_cap.return_value
     mock_instance.isOpened.return_value = True
 
-    # 640x480 webcam frame — at or below DETECTION_WIDTH, triggers single-stage
     dummy_frame = np.zeros((480, 640, 3), dtype=np.uint8)
     mock_instance.read.side_effect = [(True, dummy_frame), (False, None)]
 
-    # Mock DeepFace.extract_faces to find one face
     mock_deepface_extract.return_value = [{
         'face': np.zeros((160, 160, 3), dtype=np.float32),
         'facial_area': {'x': 0, 'y': 0, 'w': 10, 'h': 10},
-        'confidence': 0.9
+        'confidence': 0.9,
     }]
-
-    # Mock DeepFace.represent to return dummy embedding
     mock_deepface.return_value = [{"embedding": [0.1] * 512}]
 
-    # DB returns a match, then no cooldown
     mock_cur.fetchone.side_effect = [(101, "Test User", 0.1), None]
 
     mocker.patch("cv2.imshow")
+    mocker.patch("cv2.imwrite")
     mocker.patch("cv2.waitKey", return_value=ord('q'))
     mocker.patch("cv2.destroyAllWindows")
     mocker.patch("config.CONFIRMATION_FRAMES", 1)
 
-    # YuNet should NOT be initialized — mock to verify it's never called
     mock_yunet_create = mocker.patch("cv2.FaceDetectorYN.create")
     mocker.patch("monitor.ensure_yunet_model")
 
     monitor_main()
 
-    # YuNet should not have been used
     mock_yunet_create.assert_not_called()
-    # But DeepFace should have processed the frame directly
     assert any("INSERT INTO attendance_log" in str(call) for call in mock_cur.execute.call_args_list)
+
+
+def test_unknown_face_grouping(mock_db_conn, mocker):
+    """Test that unknown faces get assigned a group_id and logged."""
+    mocker.patch("monitor.query_database", return_value=(None, "Unknown", None))
+    mock_find = mocker.patch("monitor.find_matching_unknown_group", return_value=None)
+    mock_log = mocker.patch("monitor.log_unknown_detection")
+    mocker.patch("cv2.imwrite")
+    mocker.patch("os.path.join", return_value="data/unknown/unknown_test.jpg")
+
+    embedding = np.random.rand(512).tolist()
+    confirmation_buffer = {"id": None, "count": 0}
+    fake_image = np.zeros((100, 100, 3), dtype=np.uint8)
+
+    name = handle_recognition(embedding, confirmation_buffer, fake_image)
+
+    assert name == "Unknown"
+    mock_find.assert_called_once_with(embedding)
+    mock_log.assert_called_once()
+    call_args = mock_log.call_args[0]
+    assert call_args[0] == embedding
+    assert call_args[1] == "data/unknown/unknown_test.jpg"
+    assert call_args[2] is not None
+    assert len(call_args[2]) == 36  # UUID format
+
+
+def test_unknown_face_existing_group(mock_db_conn, mocker):
+    """Test that unknown faces matching an existing group reuse the group_id."""
+    mocker.patch("monitor.query_database", return_value=(None, "Unknown", 0.7))
+    mocker.patch("monitor.find_matching_unknown_group", return_value="existing-group-uuid")
+    mock_log = mocker.patch("monitor.log_unknown_detection")
+    mocker.patch("cv2.imwrite")
+    mocker.patch("os.path.join", return_value="data/unknown/unknown_test.jpg")
+
+    embedding = np.random.rand(512).tolist()
+    confirmation_buffer = {"id": None, "count": 0}
+    fake_image = np.zeros((100, 100, 3), dtype=np.uint8)
+
+    name = handle_recognition(embedding, confirmation_buffer, fake_image)
+
+    assert name == "Unknown"
+    assert mock_log.call_args[0][2] == "existing-group-uuid"

--- a/tests/test_enroll.py
+++ b/tests/test_enroll.py
@@ -1,44 +1,75 @@
-import pytest
 import os
-import numpy as np
+import tempfile
+
+import pytest
+
 from enroll import enroll_member
-import config
+
 
 def test_enroll_member_success(mock_db_conn, mock_deepface, mocker):
-    # Get mock connection and cursor from fixture
-    mock_conn, mock_cur = mock_db_conn
-    
-    # Mock DeepFace.represent to return a dummy embedding
+    _mock_connect, mock_cur = mock_db_conn
+
     mock_deepface.return_value = [{"embedding": [0.1] * 512}]
-    
-    # Mock os.listdir to simulate finding images
     mocker.patch("os.listdir", return_value=["face1.jpg"])
-    
-    # Run the function
+
     enroll_member("Test User", "/dummy/path")
-    
-    # Assertions
-    # Verify DeepFace was called
+
     mock_deepface.assert_called_once()
-    # Verify INSERT was called
     mock_cur.execute.assert_called()
     assert any("INSERT INTO members" in str(call) for call in mock_cur.execute.call_args_list)
-    # Check that name was passed correctly
     assert any("Test User" in str(call) for call in mock_cur.execute.call_args_list)
 
-def test_enroll_member_no_faces(mock_db_conn, mock_deepface, mocker):
-    # Get mock connection and cursor from fixture
-    mock_conn, mock_cur = mock_db_conn
 
-    # Mock DeepFace.represent to return no results
+def test_enroll_member_no_faces(mock_db_conn, mock_deepface, mocker):
+    _mock_connect, mock_cur = mock_db_conn
+
     mock_deepface.return_value = []
-    
     mocker.patch("os.listdir", return_value=["face1.jpg"])
-    
-    # Run the function
+
     enroll_member("Test User", "/dummy/path")
-    
-    # Assertions
-    # Verify DeepFace was called but NO insert occurred
+
     mock_deepface.assert_called_once()
     mock_cur.execute.assert_not_called()
+
+
+def test_enroll_member_missing_folder(mock_db_conn, mock_deepface):
+    """enroll_member should raise FileNotFoundError when folder doesn't exist."""
+    nonexistent = os.path.join(tempfile.gettempdir(), "nonexistent_folder_xyz")
+    with pytest.raises(FileNotFoundError):
+        enroll_member("Test User", nonexistent)
+
+
+def test_folder_name_generation():
+    """Test that folder auto-generation follows the expected pattern."""
+    name = "Sean Diviney"
+    parts = name.strip().split()
+    first_name = parts[0].lower()
+    last_name = parts[-1].lower() if len(parts) > 1 else first_name
+
+    folder_name = f"{first_name[0]}{last_name}"
+    assert folder_name == "sdiviney"
+
+
+def test_folder_name_generation_single_name():
+    """Test folder generation with a single-word name."""
+    name = "Madonna"
+    parts = name.strip().split()
+    first_name = parts[0].lower()
+    last_name = parts[-1].lower() if len(parts) > 1 else first_name
+
+    folder_name = f"{first_name[0]}{last_name}"
+    assert folder_name == "mmadonna"
+
+
+def test_folder_name_fallback():
+    """Test that folder generation falls back to two-letter prefix on collision."""
+    name = "Sean Diviney"
+    parts = name.strip().split()
+    first_name = parts[0].lower()
+    last_name = parts[-1].lower() if len(parts) > 1 else first_name
+
+    folder_name = f"{first_name[0]}{last_name}"
+    assert folder_name == "sdiviney"
+
+    folder_name_fallback = f"{first_name[:2]}{last_name}"
+    assert folder_name_fallback == "sediviney"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,43 +1,161 @@
 import pytest
-from datetime import datetime, timedelta
-from logger import log_check_in, log_unknown_detection
-import config
+from datetime import datetime
+
+from logger import (
+    log_check_in,
+    log_unknown_detection,
+    find_matching_unknown_group,
+    get_unknown_groups,
+    enroll_from_unknown,
+    dismiss_unknown_group,
+    save_member_image,
+)
+
 
 def test_log_check_in_cooldown(mock_db_conn):
-    # Get mock connection and cursor from fixture
-    mock_conn, mock_cur = mock_db_conn
-    
-    # Simulate that an entry WAS found within the cooldown period
-    mock_cur.fetchone.return_value = (1,) # Found an existing ID
-    
+    _mock_connect, mock_cur = mock_db_conn
+    mock_cur.fetchone.return_value = (1,)
+
     result = log_check_in(101)
-    
+
     assert result is False
-    # Verify the query was executed with the member_id
     mock_cur.execute.assert_called()
     assert mock_cur.execute.call_args[0][1][0] == 101
 
+
 def test_log_check_in_success(mock_db_conn):
-    mock_conn, mock_cur = mock_db_conn
-    
-    # Simulate NO existing entry found
+    _mock_connect, mock_cur = mock_db_conn
     mock_cur.fetchone.return_value = None
-    
+
     result = log_check_in(101)
-    
+
     assert result is True
-    # Verify INSERT was called
     assert any("INSERT INTO attendance_log" in call[0][0] for call in mock_cur.execute.call_args_list)
 
+
 def test_log_unknown_detection(mock_db_conn):
-    mock_conn, mock_cur = mock_db_conn
-    
+    _mock_connect, mock_cur = mock_db_conn
+
     embedding = [0.1] * 512
     image_path = "test.jpg"
-    
+
     result = log_unknown_detection(embedding, image_path)
-    
+
     assert result is True
-    # Verify INSERT was called with correct data
     assert any("INSERT INTO unknown_detections" in call[0][0] for call in mock_cur.execute.call_args_list)
-    assert mock_cur.execute.call_args_list[-1][0][1] == (embedding, image_path)
+    assert mock_cur.execute.call_args_list[-1][0][1] == (embedding, image_path, None)
+
+
+def test_find_matching_unknown_group_match(mock_db_conn, mocker):
+    _mock_connect, mock_cur = mock_db_conn
+    embedding = [0.1] * 512
+
+    mock_cur.fetchone.return_value = ("group-uuid-1", 0.3)
+    mocker.patch("logger.config.RECOGNITION_THRESHOLD", 0.5)
+
+    result = find_matching_unknown_group(embedding)
+    assert result == "group-uuid-1"
+
+
+def test_find_matching_unknown_group_no_match(mock_db_conn, mocker):
+    _mock_connect, mock_cur = mock_db_conn
+    embedding = [0.1] * 512
+
+    mock_cur.fetchone.return_value = ("group-uuid-1", 0.8)
+    mocker.patch("logger.config.RECOGNITION_THRESHOLD", 0.5)
+
+    result = find_matching_unknown_group(embedding)
+    assert result is None
+
+
+def test_find_matching_unknown_group_empty_table(mock_db_conn):
+    _mock_connect, mock_cur = mock_db_conn
+    embedding = [0.1] * 512
+
+    mock_cur.fetchone.return_value = None
+
+    result = find_matching_unknown_group(embedding)
+    assert result is None
+
+
+def test_get_unknown_groups(mock_db_conn):
+    _mock_connect, mock_cur = mock_db_conn
+
+    expected = [
+        ("group-1", "data/unknown/img1.jpg", 3, datetime(2023, 10, 27, 10, 0), datetime(2023, 10, 27, 10, 15)),
+    ]
+    mock_cur.fetchall.return_value = expected
+
+    result = get_unknown_groups()
+    assert result == expected
+
+
+def test_get_unknown_groups_empty(mock_db_conn):
+    _mock_connect, mock_cur = mock_db_conn
+    mock_cur.fetchall.return_value = []
+
+    result = get_unknown_groups()
+    assert result == []
+
+
+def test_enroll_from_unknown_success(mock_db_conn, mocker):
+    _mock_connect, mock_cur = mock_db_conn
+    mocker.patch("os.path.isfile", return_value=True)
+    mocker.patch("os.unlink")
+
+    mock_cur.fetchall.side_effect = [
+        [([0.1] * 512,), ([0.2] * 512,)],  # embeddings
+        [("data/unknown/img1.jpg",)],         # image paths
+    ]
+    mock_cur.fetchone.return_value = (42,)    # member_id
+
+    result = enroll_from_unknown("group-uuid-1", "John Doe")
+    assert result == 42
+
+
+def test_enroll_from_unknown_no_detections(mock_db_conn):
+    _mock_connect, mock_cur = mock_db_conn
+
+    mock_cur.fetchall.return_value = []
+
+    result = enroll_from_unknown("nonexistent", "John Doe")
+    assert result is None
+
+
+def test_dismiss_unknown_group_success(mock_db_conn, mocker):
+    _mock_connect, mock_cur = mock_db_conn
+    mocker.patch("os.path.isfile", return_value=True)
+    mocker.patch("os.unlink")
+
+    mock_cur.fetchall.return_value = [("data/unknown/img1.jpg",)]
+
+    result = dismiss_unknown_group("group-uuid-1")
+    assert result is True
+
+
+def test_dismiss_unknown_group_db_error(mock_db_conn):
+    _mock_connect, mock_cur = mock_db_conn
+
+    mock_cur.execute.side_effect = Exception("DB error")
+
+    result = dismiss_unknown_group("group-uuid-1")
+    assert result is False
+
+
+def test_save_member_image_success(mock_db_conn):
+    _mock_connect, mock_cur = mock_db_conn
+    mock_cur.rowcount = 1
+
+    result = save_member_image(101, "data/members/member_101.jpg")
+
+    assert result is True
+    assert any("UPDATE members SET image_path" in str(call) for call in mock_cur.execute.call_args_list)
+
+
+def test_save_member_image_already_exists(mock_db_conn):
+    _mock_connect, mock_cur = mock_db_conn
+    mock_cur.rowcount = 0
+
+    result = save_member_image(101, "data/members/member_101.jpg")
+
+    assert result is False


### PR DESCRIPTION
- Fix unknown faces silently ignored when no members are enrolled
- Make enroll.py --folder optional with auto-generation from --name
- Group unknown faces by embedding similarity with UUID-based group_id
- Add tabbed dashboard with Attendance and Enroll tabs
- Web enrollment: review unknown face groups, enroll or dismiss via UI
- Capture member photo on first check-in, display as thumbnail in attendance table
- Add /snapshots/, /member-photos/, /enroll, /dismiss Flask routes
- Fix Ctrl+C not stopping the monitor
- 35 tests covering all new functionality