### PR TITLE
feat: add curated unknown-face enrollment workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cp .env.example .env
    uv run monitor.py
    ```
 
-2. **Start the dashboard** (in a separate terminal):
+2. **Start the dashboard** in a separate terminal:
    ```bash
    uv run app.py
    ```
@@ -72,7 +72,7 @@ uv run enroll.py --name "Sean Diviney"
 uv run enroll.py --name "Sean Diviney" --folder data/faces/sdiviney/
 ```
 
-Then start the monitor and dashboard:
+Then start the monitor and dashboard in separate terminals:
 ```bash
 uv run monitor.py
 uv run app.py     # http://localhost:5000

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from logger import (
     enroll_from_unknown,
     ensure_archive_table,
     get_attendance_logs,
+    get_member_names,
     get_unknown_groups,
 )
 
@@ -31,8 +32,15 @@ threading.Thread(target=_run_archive_loop, daemon=True).start()
 @app.route('/')
 def index():
     logs = get_attendance_logs()
+    member_names = get_member_names()
     unknown_groups = get_unknown_groups()
-    return render_template('index.html', logs=logs, unknown_groups=unknown_groups, now=datetime.now())
+    return render_template(
+        'index.html',
+        logs=logs,
+        member_names=member_names,
+        unknown_groups=unknown_groups,
+        now=datetime.now(),
+    )
 
 
 @app.route('/snapshots/<filename>')
@@ -48,25 +56,36 @@ def serve_member_photo(filename):
 @app.route('/enroll', methods=['POST'])
 def enroll():
     data = request.get_json()
+    detection_ids = data.get('detection_ids') if data else None
     if not data or not data.get('group_id') or not data.get('name', '').strip():
         return jsonify({"error": "Missing name or group_id"}), 400
+    if not isinstance(detection_ids, list) or not detection_ids:
+        return jsonify({"error": "Select at least one photo"}), 400
 
-    member_id = enroll_from_unknown(data['group_id'], data['name'].strip())
-    if member_id is None:
-        return jsonify({"error": "No detections found for group_id"}), 404
+    result = enroll_from_unknown(data['group_id'], data['name'].strip(), detection_ids)
+    if result is None:
+        return jsonify({"error": "No selected detections found for group_id"}), 404
 
-    return jsonify({"success": True, "member_id": member_id, "name": data['name'].strip()})
+    return jsonify({
+        "success": True,
+        "member_id": result["member_id"],
+        "name": data['name'].strip(),
+        "action": result["action"],
+    })
 
 
 @app.route('/dismiss', methods=['POST'])
 def dismiss():
     data = request.get_json()
+    detection_ids = data.get('detection_ids') if data else None
     if not data or not data.get('group_id'):
         return jsonify({"error": "Missing group_id"}), 400
+    if not isinstance(detection_ids, list) or not detection_ids:
+        return jsonify({"error": "Select at least one photo"}), 400
 
-    success = dismiss_unknown_group(data['group_id'])
+    success = dismiss_unknown_group(data['group_id'], detection_ids)
     if not success:
-        return jsonify({"error": "Failed to dismiss group"}), 500
+        return jsonify({"error": "Failed to dismiss selected photos"}), 500
 
     return jsonify({"success": True})
 

--- a/logger.py
+++ b/logger.py
@@ -155,20 +155,38 @@ def find_matching_unknown_group(embedding):
 
 
 def get_unknown_groups():
-    """Get summary of unknown face groups for the dashboard."""
+    """Get unknown face groups with their selectable detections for the dashboard."""
     try:
         with _db_cursor() as cur:
             cur.execute(
-                "SELECT ud.group_id, MIN(ud.image_path) AS image_path, "
-                "COUNT(*) AS seen_count, "
-                "MIN(ud.detected_at) AS first_seen, "
-                "MAX(ud.detected_at) AS last_seen "
+                "SELECT ud.id, ud.group_id, ud.image_path, ud.detected_at "
                 "FROM unknown_detections ud "
                 "WHERE ud.group_id IS NOT NULL "
-                "GROUP BY ud.group_id "
-                "ORDER BY MAX(ud.detected_at) DESC"
+                "ORDER BY ud.group_id, ud.detected_at DESC"
             )
-            return cur.fetchall()
+            rows = cur.fetchall()
+
+        groups = {}
+        for detection_id, group_id, image_path, detected_at in rows:
+            group = groups.setdefault(group_id, {
+                "group_id": group_id,
+                "seen_count": 0,
+                "first_seen": detected_at,
+                "last_seen": detected_at,
+                "detections": [],
+            })
+            group["seen_count"] += 1
+            if detected_at < group["first_seen"]:
+                group["first_seen"] = detected_at
+            if detected_at > group["last_seen"]:
+                group["last_seen"] = detected_at
+            group["detections"].append({
+                "id": detection_id,
+                "image_path": image_path,
+                "detected_at": detected_at,
+            })
+
+        return sorted(groups.values(), key=lambda group: group["last_seen"], reverse=True)
     except Exception as e:
         print(f"Error fetching unknown groups: {e}")
         return []
@@ -191,7 +209,6 @@ def get_attendance_logs(limit=100):
     except Exception as exc:
         print(f"Error fetching attendance logs: {exc}")
         return []
-
 
 def archive_old_attendance():
     """Move attendance records older than the session window to the archive table."""
@@ -218,6 +235,21 @@ def archive_old_attendance():
         return 0
 
 
+def get_member_names():
+    """Fetch member names for enrollment suggestions."""
+    try:
+        with _db_cursor() as cur:
+            cur.execute(
+                "SELECT id, name "
+                "FROM members "
+                "ORDER BY LOWER(name) ASC"
+            )
+            return cur.fetchall()
+    except Exception as e:
+        print(f"Error fetching member names: {e}")
+        return []
+
+
 def _delete_snapshot_files(image_paths):
     """Remove snapshot image files from disk, ignoring missing files."""
     for path in image_paths:
@@ -237,6 +269,32 @@ def _get_group_image_paths(cur, group_id):
     return [row[0] for row in cur.fetchall()]
 
 
+def _normalize_detection_ids(detection_ids):
+    if not detection_ids:
+        return []
+    normalized = []
+    for detection_id in detection_ids:
+        try:
+            normalized.append(int(detection_id))
+        except (TypeError, ValueError):
+            continue
+    return sorted(set(normalized))
+
+
+def _get_selected_detections(cur, group_id, detection_ids):
+    normalized_ids = _normalize_detection_ids(detection_ids)
+    if not normalized_ids:
+        return []
+
+    cur.execute(
+        "SELECT id, face_embedding, image_path "
+        "FROM unknown_detections "
+        "WHERE group_id = %s AND id = ANY(%s)",
+        (group_id, normalized_ids),
+    )
+    return cur.fetchall()
+
+
 def _parse_embedding(value):
     """Parse an embedding from pgvector, which may be a string or a list."""
     if isinstance(value, str):
@@ -244,50 +302,76 @@ def _parse_embedding(value):
     return value
 
 
-def enroll_from_unknown(group_id, name):
-    """Enroll a member from unknown detection group. Returns member_id or None."""
+def _find_member_by_name(cur, name):
+    cur.execute(
+        "SELECT id, name, face_embedding "
+        "FROM members "
+        "WHERE LOWER(TRIM(name)) = LOWER(TRIM(%s)) "
+        "LIMIT 1",
+        (name,),
+    )
+    return cur.fetchone()
+
+
+def enroll_from_unknown(group_id, name, detection_ids):
+    """Create or update a member from selected detections within an unknown group."""
     try:
         with _db_cursor(commit=True) as cur:
-            cur.execute(
-                "SELECT face_embedding FROM unknown_detections WHERE group_id = %s",
-                (group_id,),
-            )
-            rows = cur.fetchall()
+            rows = _get_selected_detections(cur, group_id, detection_ids)
             if not rows:
                 return None
 
-            embeddings = [np.array(_parse_embedding(row[0])) for row in rows]
-            avg_embedding = np.mean(embeddings, axis=0).tolist()
+            selected_ids = [row[0] for row in rows]
+            embeddings = [np.array(_parse_embedding(row[1])) for row in rows]
+            selected_embedding = np.mean(embeddings, axis=0)
+            image_paths = [row[2] for row in rows]
+
+            existing_member = _find_member_by_name(cur, name)
+            if existing_member:
+                member_id = existing_member[0]
+                existing_embedding = np.array(_parse_embedding(existing_member[2]))
+                merged_embedding = np.mean([existing_embedding, selected_embedding], axis=0).tolist()
+                cur.execute(
+                    "UPDATE members SET face_embedding = %s WHERE id = %s",
+                    (merged_embedding, member_id),
+                )
+                action = "updated"
+            else:
+                cur.execute(
+                    "INSERT INTO members (name, face_embedding) VALUES (%s, %s) RETURNING id",
+                    (name, selected_embedding.tolist()),
+                )
+                member_id = cur.fetchone()[0]
+                action = "created"
 
             cur.execute(
-                "INSERT INTO members (name, face_embedding) VALUES (%s, %s) RETURNING id",
-                (name, avg_embedding),
-            )
-            member_id = cur.fetchone()[0]
-
-            image_paths = _get_group_image_paths(cur, group_id)
-
-            cur.execute(
-                "DELETE FROM unknown_detections WHERE group_id = %s",
-                (group_id,),
+                "DELETE FROM unknown_detections "
+                "WHERE group_id = %s AND id = ANY(%s)",
+                (group_id, selected_ids),
             )
 
         _delete_snapshot_files(image_paths)
-        return member_id
+        return {"member_id": member_id, "action": action}
     except Exception as e:
         print(f"Error enrolling from unknown: {e}")
         return None
 
 
-def dismiss_unknown_group(group_id):
-    """Delete an unknown group and its snapshots. Returns True on success."""
+def dismiss_unknown_group(group_id, detection_ids):
+    """Delete selected detections from an unknown group. Returns True on success."""
     try:
         with _db_cursor(commit=True) as cur:
-            image_paths = _get_group_image_paths(cur, group_id)
+            rows = _get_selected_detections(cur, group_id, detection_ids)
+            if not rows:
+                return False
+
+            selected_ids = [row[0] for row in rows]
+            image_paths = [row[2] for row in rows]
 
             cur.execute(
-                "DELETE FROM unknown_detections WHERE group_id = %s",
-                (group_id,),
+                "DELETE FROM unknown_detections "
+                "WHERE group_id = %s AND id = ANY(%s)",
+                (group_id, selected_ids),
             )
 
         _delete_snapshot_files(image_paths)

--- a/monitor.py
+++ b/monitor.py
@@ -1,6 +1,5 @@
 import os
 import psycopg2
-import threading
 import uuid
 from datetime import datetime
 
@@ -9,7 +8,6 @@ import numpy as np
 from deepface import DeepFace
 
 import config
-from app import app
 from logger import (
     find_matching_unknown_group,
     log_check_in,
@@ -289,20 +287,9 @@ def process_frame_two_stage(frame, yunet, confirmation_buffer):
     return display_frame
 
 
-def start_web_server():
-    """Start the Flask web server in a background thread."""
-    try:
-        app.run(host="0.0.0.0", port=config.FLASK_PORT, debug=False, use_reloader=False)
-    except Exception as e:
-        print(f"Failed to start web server: {e}")
-
-
 def main():
-    web_thread = threading.Thread(target=start_web_server, daemon=True)
-    web_thread.start()
-
     print("\n--- Face Attendance Monitoring ---")
-    print(f"Log Viewer available at: http://localhost:{config.FLASK_PORT}")
+    print(f"Dashboard available separately at: http://localhost:{config.FLASK_PORT}")
     print("Press 'q' in the camera window or Ctrl+C to exit.\n")
 
     cap = cv2.VideoCapture(config.CAMERA_SOURCE)

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,8 +10,11 @@
         body { background-color: #f8f9fa; }
         .container { margin-top: 30px; }
         .header { margin-bottom: 20px; border-bottom: 2px solid #dee2e6; padding-bottom: 15px; }
-        .unknown-card img { width: 100%; height: 200px; object-fit: cover; border-radius: 4px; }
         .unknown-card { margin-bottom: 20px; }
+        .detection-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin-bottom: 16px; }
+        .detection-option { border: 1px solid #dee2e6; border-radius: 8px; padding: 8px; background: #fff; }
+        .detection-option img { width: 100%; height: 140px; object-fit: cover; border-radius: 6px; margin-top: 8px; }
+        .selection-summary { font-size: 0.9rem; color: #6c757d; margin-bottom: 12px; }
     </style>
 </head>
 <body>
@@ -19,6 +22,12 @@
         <div class="header">
             <h1 class="display-4">Face Attendance</h1>
         </div>
+
+        <datalist id="member-name-options">
+            {% for member in member_names %}
+            <option value="{{ member[1] }}"></option>
+            {% endfor %}
+        </datalist>
 
         <ul class="nav nav-tabs mb-4" id="mainTabs" role="tablist">
             <li class="nav-item" role="presentation">
@@ -76,27 +85,54 @@
                 {% if unknown_groups %}
                     <div class="row">
                         {% for group in unknown_groups %}
-                        <div class="col-md-4 col-lg-3">
+                        <div class="col-md-6 col-xl-4">
                             <div class="card unknown-card shadow-sm">
-                                <img src="/snapshots/{{ group[1].split('/')[-1] }}" class="card-img-top" alt="Unknown face">
                                 <div class="card-body">
                                     <p class="card-text mb-1">
-                                        <strong>Seen:</strong> {{ group[2] }} time{{ 's' if group[2] != 1 else '' }}
+                                        <strong>Seen:</strong> {{ group.seen_count }} time{{ 's' if group.seen_count != 1 else '' }}
                                     </p>
                                     <p class="card-text mb-1">
-                                        <small class="text-muted">First: {{ group[3].strftime('%I:%M %p') }}</small>
+                                        <small class="text-muted">First: {{ group.first_seen.strftime('%I:%M %p') }}</small>
                                     </p>
-                                    {% if group[2] > 1 %}
+                                    {% if group.seen_count > 1 %}
                                     <p class="card-text mb-2">
-                                        <small class="text-muted">Last: {{ group[4].strftime('%I:%M %p') }}</small>
+                                        <small class="text-muted">Last: {{ group.last_seen.strftime('%I:%M %p') }}</small>
                                     </p>
                                     {% endif %}
+                                    <div class="selection-summary" id="selection-summary-{{ group.group_id }}"></div>
+                                    <div class="detection-grid">
+                                        {% for detection in group.detections %}
+                                        <label class="detection-option">
+                                            <div>
+                                                <input
+                                                    type="checkbox"
+                                                    class="form-check-input detection-checkbox"
+                                                    data-group-id="{{ group.group_id }}"
+                                                    value="{{ detection.id }}"
+                                                    checked
+                                                    onchange="updateSelectionSummary('{{ group.group_id }}')"
+                                                >
+                                                <span>Select photo</span>
+                                            </div>
+                                            <img src="/snapshots/{{ detection.image_path.split('/')[-1] }}" alt="Unknown face">
+                                            <div class="mt-2">
+                                                <small class="text-muted">{{ detection.detected_at.strftime('%I:%M:%S %p') }}</small>
+                                            </div>
+                                        </label>
+                                        {% endfor %}
+                                    </div>
                                     <div class="input-group mb-2">
-                                        <input type="text" class="form-control form-control-sm" placeholder="Name" id="name-{{ group[0] }}">
+                                        <input
+                                            type="text"
+                                            class="form-control form-control-sm"
+                                            placeholder="Name"
+                                            id="name-{{ group.group_id }}"
+                                            list="member-name-options"
+                                        >
                                     </div>
                                     <div class="d-flex gap-2">
-                                        <button class="btn btn-success btn-sm flex-fill" onclick="enrollFace('{{ group[0] }}')">Enroll</button>
-                                        <button class="btn btn-outline-danger btn-sm flex-fill" onclick="dismissFace('{{ group[0] }}')">Dismiss</button>
+                                        <button class="btn btn-success btn-sm flex-fill" onclick="enrollFace('{{ group.group_id }}')">Enroll Selected</button>
+                                        <button class="btn btn-outline-danger btn-sm flex-fill" onclick="dismissFace('{{ group.group_id }}')">Dismiss Selected</button>
                                     </div>
                                 </div>
                             </div>
@@ -118,23 +154,65 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
+        const ACTIVE_TAB_KEY = 'face-attendance-active-tab';
+
+        function setActiveTab(tabId) {
+            localStorage.setItem(ACTIVE_TAB_KEY, tabId);
+        }
+
+        function restoreActiveTab() {
+            const savedTab = window.location.hash || localStorage.getItem(ACTIVE_TAB_KEY);
+            if (!savedTab) {
+                return;
+            }
+
+            const tabButton = document.querySelector(`[data-bs-target="${savedTab}"]`);
+            if (tabButton) {
+                bootstrap.Tab.getOrCreateInstance(tabButton).show();
+            }
+        }
+
+        function getSelectedDetectionIds(groupId) {
+            return Array.from(document.querySelectorAll(`.detection-checkbox[data-group-id="${groupId}"]:checked`))
+                .map(input => Number(input.value));
+        }
+
+        function updateSelectionSummary(groupId) {
+            const selectedCount = getSelectedDetectionIds(groupId).length;
+            const totalCount = document.querySelectorAll(`.detection-checkbox[data-group-id="${groupId}"]`).length;
+            const summary = document.getElementById('selection-summary-' + groupId);
+            if (summary) {
+                summary.textContent = `${selectedCount} of ${totalCount} photos selected`;
+            }
+        }
+
         function enrollFace(groupId) {
             const nameInput = document.getElementById('name-' + groupId);
             const name = nameInput.value.trim();
+            const detectionIds = getSelectedDetectionIds(groupId);
             if (!name) {
                 nameInput.classList.add('is-invalid');
                 return;
             }
             nameInput.classList.remove('is-invalid');
+            if (!detectionIds.length) {
+                alert('Select at least one photo to enroll.');
+                return;
+            }
 
             fetch('/enroll', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ group_id: groupId, name: name })
+                body: JSON.stringify({ group_id: groupId, name: name, detection_ids: detectionIds })
             })
             .then(r => r.json())
             .then(data => {
                 if (data.success) {
+                    setActiveTab('#enroll');
+                    const message = data.action === 'updated'
+                        ? `Added photos to existing member ${data.name}.`
+                        : `Created member ${data.name}.`;
+                    alert(message);
                     location.reload();
                 } else {
                     alert('Error: ' + (data.error || 'Unknown error'));
@@ -144,14 +222,20 @@
         }
 
         function dismissFace(groupId) {
+            const detectionIds = getSelectedDetectionIds(groupId);
+            if (!detectionIds.length) {
+                alert('Select at least one photo to dismiss.');
+                return;
+            }
             fetch('/dismiss', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ group_id: groupId })
+                body: JSON.stringify({ group_id: groupId, detection_ids: detectionIds })
             })
             .then(r => r.json())
             .then(data => {
                 if (data.success) {
+                    setActiveTab('#enroll');
                     location.reload();
                 } else {
                     alert('Error: ' + (data.error || 'Unknown error'));
@@ -159,6 +243,18 @@
             })
             .catch(err => alert('Request failed: ' + err));
         }
+
+        document.querySelectorAll('[id^="selection-summary-"]').forEach(el => {
+            updateSelectionSummary(el.id.replace('selection-summary-', ''));
+        });
+
+        document.querySelectorAll('[data-bs-toggle="tab"]').forEach(tabButton => {
+            tabButton.addEventListener('shown.bs.tab', event => {
+                setActiveTab(event.target.getAttribute('data-bs-target'));
+            });
+        });
+
+        restoreActiveTab();
     </script>
 </body>
 </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,6 +16,7 @@ def test_index_route(client, mocker):
         ("data/members/member_1.jpg", "John Doe", datetime(2023, 10, 27, 10, 0, 0)),
         ("data/members/member_2.jpg", "Jane Smith", datetime(2023, 10, 27, 10, 5, 0)),
     ])
+    mocker.patch("app.get_member_names", return_value=[])
     mocker.patch("app.get_unknown_groups", return_value=[])
 
     response = client.get('/')
@@ -27,6 +28,7 @@ def test_index_route(client, mocker):
 
 def test_index_no_logs(client, mocker):
     mocker.patch("app.get_attendance_logs", return_value=[])
+    mocker.patch("app.get_member_names", return_value=[])
     mocker.patch("app.get_unknown_groups", return_value=[])
 
     response = client.get('/')
@@ -35,25 +37,31 @@ def test_index_no_logs(client, mocker):
 
 
 def test_enroll_success(client, mocker):
-    mocker.patch("app.enroll_from_unknown", return_value=42)
+    mocker.patch("app.enroll_from_unknown", return_value={"member_id": 42, "action": "created"})
 
     response = client.post('/enroll',
-        json={"group_id": "abc-123", "name": "John Doe"})
+        json={"group_id": "abc-123", "name": "John Doe", "detection_ids": [1, 2]})
 
     assert response.status_code == 200
     data = response.get_json()
     assert data["success"] is True
     assert data["member_id"] == 42
     assert data["name"] == "John Doe"
+    assert data["action"] == "created"
 
 
 def test_enroll_missing_name(client, mocker):
-    response = client.post('/enroll', json={"group_id": "abc-123"})
+    response = client.post('/enroll', json={"group_id": "abc-123", "detection_ids": [1]})
     assert response.status_code == 400
 
 
 def test_enroll_missing_group_id(client, mocker):
-    response = client.post('/enroll', json={"name": "John Doe"})
+    response = client.post('/enroll', json={"name": "John Doe", "detection_ids": [1]})
+    assert response.status_code == 400
+
+
+def test_enroll_missing_detection_ids(client, mocker):
+    response = client.post('/enroll', json={"group_id": "abc-123", "name": "John Doe"})
     assert response.status_code == 400
 
 
@@ -61,7 +69,7 @@ def test_enroll_group_not_found(client, mocker):
     mocker.patch("app.enroll_from_unknown", return_value=None)
 
     response = client.post('/enroll',
-        json={"group_id": "nonexistent", "name": "John Doe"})
+        json={"group_id": "nonexistent", "name": "John Doe", "detection_ids": [5]})
 
     assert response.status_code == 404
 
@@ -69,7 +77,7 @@ def test_enroll_group_not_found(client, mocker):
 def test_dismiss_success(client, mocker):
     mocker.patch("app.dismiss_unknown_group", return_value=True)
 
-    response = client.post('/dismiss', json={"group_id": "abc-123"})
+    response = client.post('/dismiss', json={"group_id": "abc-123", "detection_ids": [1, 2]})
 
     assert response.status_code == 200
     data = response.get_json()
@@ -77,14 +85,19 @@ def test_dismiss_success(client, mocker):
 
 
 def test_dismiss_missing_group_id(client, mocker):
-    response = client.post('/dismiss', json={})
+    response = client.post('/dismiss', json={"detection_ids": [1]})
+    assert response.status_code == 400
+
+
+def test_dismiss_missing_detection_ids(client, mocker):
+    response = client.post('/dismiss', json={"group_id": "abc-123"})
     assert response.status_code == 400
 
 
 def test_dismiss_failure(client, mocker):
     mocker.patch("app.dismiss_unknown_group", return_value=False)
 
-    response = client.post('/dismiss', json={"group_id": "abc-123"})
+    response = client.post('/dismiss', json={"group_id": "abc-123", "detection_ids": [1]})
 
     assert response.status_code == 500
 
@@ -111,6 +124,7 @@ def test_index_renders_member_photo(client, mocker):
         ("data/members/member_1.jpg", "John Doe", datetime(2023, 10, 27, 10, 0, 0)),
         (None, "Jane Smith", datetime(2023, 10, 27, 10, 5, 0)),
     ])
+    mocker.patch("app.get_member_names", return_value=[])
     mocker.patch("app.get_unknown_groups", return_value=[])
 
     response = client.get('/')
@@ -121,12 +135,32 @@ def test_index_renders_member_photo(client, mocker):
 
 def test_index_with_unknown_groups(client, mocker):
     mocker.patch("app.get_attendance_logs", return_value=[])
+    mocker.patch("app.get_member_names", return_value=[(1, "John Doe"), (2, "Jane Smith")])
     mocker.patch("app.get_unknown_groups", return_value=[
-        ("group-uuid-1", "data/unknown/unknown_20231027_100000.jpg", 3,
-         datetime(2023, 10, 27, 10, 0, 0), datetime(2023, 10, 27, 10, 15, 0)),
+        {
+            "group_id": "group-uuid-1",
+            "seen_count": 3,
+            "first_seen": datetime(2023, 10, 27, 10, 0, 0),
+            "last_seen": datetime(2023, 10, 27, 10, 15, 0),
+            "detections": [
+                {
+                    "id": 10,
+                    "image_path": "data/unknown/unknown_20231027_100000.jpg",
+                    "detected_at": datetime(2023, 10, 27, 10, 0, 0),
+                },
+                {
+                    "id": 11,
+                    "image_path": "data/unknown/unknown_20231027_100100.jpg",
+                    "detected_at": datetime(2023, 10, 27, 10, 1, 0),
+                },
+            ],
+        },
     ])
 
     response = client.get('/')
     assert response.status_code == 200
     assert b"Enroll" in response.data
     assert b"3 times" in response.data
+    assert b"Select photo" in response.data
+    assert b"member-name-options" in response.data
+    assert b"John Doe" in response.data

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -8,7 +8,6 @@ from monitor import main as monitor_main, handle_recognition
 def mock_monitor_infra(mocker):
     """Mock blocking infrastructure in monitor.py for all tests in this module."""
     mocker.patch("builtins.input", return_value="n")
-    mocker.patch("monitor.threading.Thread")
     return
 
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -8,6 +8,7 @@ from logger import (
     enroll_from_unknown,
     find_matching_unknown_group,
     get_attendance_logs,
+    get_member_names,
     get_unknown_groups,
     log_check_in,
     log_unknown_detection,
@@ -84,13 +85,18 @@ def test_find_matching_unknown_group_empty_table(mock_db_conn):
 def test_get_unknown_groups(mock_db_conn):
     _mock_connect, mock_cur = mock_db_conn
 
-    expected = [
-        ("group-1", "data/unknown/img1.jpg", 3, datetime(2023, 10, 27, 10, 0), datetime(2023, 10, 27, 10, 15)),
+    mock_cur.fetchall.return_value = [
+        (1, "group-1", "data/unknown/img2.jpg", datetime(2023, 10, 27, 10, 15)),
+        (2, "group-1", "data/unknown/img1.jpg", datetime(2023, 10, 27, 10, 0)),
     ]
-    mock_cur.fetchall.return_value = expected
 
     result = get_unknown_groups()
-    assert result == expected
+    assert len(result) == 1
+    assert result[0]["group_id"] == "group-1"
+    assert result[0]["seen_count"] == 2
+    assert result[0]["first_seen"] == datetime(2023, 10, 27, 10, 0)
+    assert result[0]["last_seen"] == datetime(2023, 10, 27, 10, 15)
+    assert result[0]["detections"][0]["id"] == 1
 
 
 def test_get_unknown_groups_empty(mock_db_conn):
@@ -101,19 +107,47 @@ def test_get_unknown_groups_empty(mock_db_conn):
     assert result == []
 
 
+def test_get_member_names(mock_db_conn):
+    _mock_connect, mock_cur = mock_db_conn
+    mock_cur.fetchall.return_value = [(2, "Jane Smith"), (1, "John Doe")]
+
+    result = get_member_names()
+    assert result == [(2, "Jane Smith"), (1, "John Doe")]
+
+
 def test_enroll_from_unknown_success(mock_db_conn, mocker):
     _mock_connect, mock_cur = mock_db_conn
     mocker.patch("os.path.isfile", return_value=True)
     mocker.patch("os.unlink")
 
     mock_cur.fetchall.side_effect = [
-        [([0.1] * 512,), ([0.2] * 512,)],  # embeddings
-        [("data/unknown/img1.jpg",)],         # image paths
+        [
+            (10, [0.1] * 512, "data/unknown/img1.jpg"),
+            (11, [0.2] * 512, "data/unknown/img2.jpg"),
+        ],
     ]
-    mock_cur.fetchone.return_value = (42,)    # member_id
+    mock_cur.fetchone.side_effect = [None, (42,)]
 
-    result = enroll_from_unknown("group-uuid-1", "John Doe")
-    assert result == 42
+    result = enroll_from_unknown("group-uuid-1", "John Doe", [10, 11])
+    assert result == {"member_id": 42, "action": "created"}
+
+
+def test_enroll_from_unknown_updates_existing_member(mock_db_conn, mocker):
+    _mock_connect, mock_cur = mock_db_conn
+    mocker.patch("os.path.isfile", return_value=True)
+    mocker.patch("os.unlink")
+
+    mock_cur.fetchall.side_effect = [
+        [
+            (10, [0.1] * 512, "data/unknown/img1.jpg"),
+            (11, [0.3] * 512, "data/unknown/img2.jpg"),
+        ],
+    ]
+    mock_cur.fetchone.return_value = (7, "John Doe", [0.5] * 512)
+
+    result = enroll_from_unknown("group-uuid-1", "John Doe", [10, 11])
+    assert result == {"member_id": 7, "action": "updated"}
+    assert any("UPDATE members SET face_embedding" in call[0][0] for call in mock_cur.execute.call_args_list)
 
 
 def test_enroll_from_unknown_no_detections(mock_db_conn):
@@ -121,7 +155,7 @@ def test_enroll_from_unknown_no_detections(mock_db_conn):
 
     mock_cur.fetchall.return_value = []
 
-    result = enroll_from_unknown("nonexistent", "John Doe")
+    result = enroll_from_unknown("nonexistent", "John Doe", [999])
     assert result is None
 
 
@@ -130,9 +164,9 @@ def test_dismiss_unknown_group_success(mock_db_conn, mocker):
     mocker.patch("os.path.isfile", return_value=True)
     mocker.patch("os.unlink")
 
-    mock_cur.fetchall.return_value = [("data/unknown/img1.jpg",)]
+    mock_cur.fetchall.return_value = [(10, [0.1] * 512, "data/unknown/img1.jpg")]
 
-    result = dismiss_unknown_group("group-uuid-1")
+    result = dismiss_unknown_group("group-uuid-1", [10])
     assert result is True
 
 
@@ -141,7 +175,7 @@ def test_dismiss_unknown_group_db_error(mock_db_conn):
 
     mock_cur.execute.side_effect = Exception("DB error")
 
-    result = dismiss_unknown_group("group-uuid-1")
+    result = dismiss_unknown_group("group-uuid-1", [10])
     assert result is False
 
 


### PR DESCRIPTION
his PR upgrades the unknown-face enrollment flow so operators can curate detections before acting on them.

Instead of enrolling or dismissing an entire unknown group at once, the dashboard now renders each group as a set of selectable photos. Operators can choose the exact snapshots they want to use, then either:

- enroll those selected photos into a new member
- type an existing member name and use the selected photos to improve that member’s embedding
- dismiss only the selected photos

The Enroll tab also now stays active after these actions so the review workflow is smoother.

Changes

- add per-photo checkbox selection for unknown detections
- send `detection_ids` with enroll and dismiss requests
- group unknown detections into richer view models for the template
- resolve member names against existing members before creating a new record
- update an existing member embedding when selected detections are applied to that member
- add member-name suggestions via a datalist in the enroll form
- persist the active tab so post-action reloads stay on Enroll
- expand tests for the new API shape and enrollment behavior
